### PR TITLE
Update Reading Validation-Allow Empty Binary Data (#241)

### DIFF
--- a/models/reading.go
+++ b/models/reading.go
@@ -48,6 +48,12 @@ const (
 )
 
 // Reading contains data that was gathered from a device.
+//
+// NOTE a Reading's BinaryValue is not to be persisted in the database. This architectural decision requires that
+// serialization validation be relaxed for enforcing the presence of binary data for Binary ValueTypes. Also, that
+// issuing GET operations to obtain Readings directly or indirectly via Events will result in a Reading with no
+// BinaryValue for Readings with a ValueType of Binary. BinaryValue is to be present when creating or updating a Reading
+// either directly, indirectly via an Event, and when the information is put on the EventBus.
 type Reading struct {
 	Id            string `json:"id,omitempty" codec:"id,omitempty"`
 	Pushed        int64  `json:"pushed,omitempty" codec:"pushed,omitempty"`   // When the data was pushed out of EdgeX (0 - not pushed yet)
@@ -61,9 +67,11 @@ type Reading struct {
 	DataType      string `json:"dataType,omitempty" codec:"dataType,omitempty"`
 	UomLabel      string `json:"uomLabel,omitempty" codec:"uomLabel,omitempty"`
 	FloatEncoding string `json:"floatEncoding,omitempty" codec:"floatEncoding,omitempty"`
-	BinaryValue   []byte `json:"binaryValue,omitempty" codec:"binaryValue,omitempty"` // Binary data payload
-	MediaType     string `json:"mediaType,omitempty" codec:"mediaType,omitempty"`
-	isValidated   bool   // internal member used for validation check
+	// BinaryValue binary data payload. This information is not persisted in the Database and is expected to be empty
+	// when retrieving a Reading for the ValueType of Binary.
+	BinaryValue []byte `json:"binaryValue,omitempty" codec:"binaryValue,omitempty"`
+	MediaType   string `json:"mediaType,omitempty" codec:"mediaType,omitempty"`
+	isValidated bool   // internal member used for validation check
 }
 
 // UnmarshalJSON implements the Unmarshaler interface for the Reading type
@@ -140,12 +148,21 @@ func (r Reading) Validate() (bool, error) {
 	if r.Name == "" {
 		return false, NewErrContractInvalid("name for reading's value descriptor not specified")
 	}
-	if r.Value == "" && len(r.BinaryValue) == 0 {
+	// We do not expect the BinaryValue to always be present. This is due to an architectural decision to not persist
+	// Binary readings to save on memory. This means that the BinaryValue is only expected to be populated when creating
+	// a new reading or event. Otherwise the value will be empty as it will be coming from the database where we are
+	// explicitly not storing the information.
+	if r.ValueType != ValueTypeBinary && r.Value == "" {
 		return false, NewErrContractInvalid("reading has no value")
 	}
+
+	// Even though we do not want to enforce the BinaryValue always being present for Readings, we still want to enforce
+	// the MediaType being specified when the BinaryValue is provided. This will most likely only take affect when
+	// creating and updating events or readings.
 	if len(r.BinaryValue) != 0 && len(r.MediaType) == 0 {
 		return false, NewErrContractInvalid("media type must be specified for binary values")
 	}
+
 	if (r.ValueType == ValueTypeFloat32 || r.ValueType == ValueTypeFloat64) && len(r.FloatEncoding) == 0 {
 		return false, NewErrContractInvalid("float encoding must be specified for float values")
 	}

--- a/models/reading_test.go
+++ b/models/reading_test.go
@@ -70,23 +70,26 @@ func TestReadingValidation(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		r           Reading
+		reading     Reading
 		expectError bool
 	}{
 		{"valid reading", valid, false},
 		{"empty device", Reading{Name: "test", Value: "0"}, false},
-		{"invalid name", Reading{Device: "test", Value: "0"}, true},
-		{"invalid value", Reading{Device: "test", Name: "test"}, true},
+		{"missing name", Reading{Device: "test", Value: "0"}, true},
+		{"missing value", Reading{Device: "test", Name: "test"}, true},
 		{"missing media type", Reading{Name: "test", BinaryValue: TestBinaryValue}, true},
-		{"media type present", Reading{Name: "test", BinaryValue: TestBinaryValue, MediaType: TestMediaType}, false},
+		{"media type present", Reading{Name: "test", Value: "test", MediaType: TestMediaType}, false},
 		{"missing float encoding f64", Reading{Name: "test", ValueType: ValueTypeFloat64, Value: "3.14"}, true},
 		{"missing float encoding f32", Reading{Name: "test", ValueType: ValueTypeFloat32, Value: "3.14"}, true},
 		{"valid float f64", Reading{Name: "test", ValueType: ValueTypeFloat64, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
 		{"valid float f32", Reading{Name: "test", ValueType: ValueTypeFloat32, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
+		{"valid empty binary value", Reading{Name: "test", ValueType: ValueTypeBinary}, false},
+		{"valid binary value", Reading{Name: "test", ValueType: ValueTypeBinary, BinaryValue: TestBinaryValue, MediaType: TestMediaType}, false},
+		{"missing media type for binary reading", Reading{Name: "test", ValueType: ValueTypeBinary, BinaryValue: TestBinaryValue}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.r.Validate()
+			_, err := tt.reading.Validate()
 			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}


### PR DESCRIPTION
Fix #240

Update the validation of Reading to allow for empty `BinaryValue`. This
is needed since architecturally we are not persisting binary readings.
This means that Readings with a `ValueType` of `Binary` the
`BinaryValue` field is expected to be empty when obtaining existing
Readings. However, the `BinaryValue` field is still useful when creating
or updating an existing Reading as the data is expected to be populated.
Therefore, we must still enforce some validation such a the `MediaType`
being present when a `BinaryValue` is provided.

Update validation tests to accommodate the new changes and expectations.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>
(cherry picked from commit ecf948a463e8583f0496661ae04077e126abfeb1)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information