### PR TITLE
EDX-462 Normalize reading's valueType letter case

### DIFF
--- a/models/reading.go
+++ b/models/reading.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"encoding/json"
+	"strings"
 )
 
 // Constants related to Reading ValueTypes
@@ -114,7 +115,7 @@ func (r *Reading) UnmarshalJSON(data []byte) error {
 		r.Value = *a.Value
 	}
 	if a.ValueType != nil {
-		r.ValueType = *a.ValueType
+		r.ValueType = normalizeValueTypeCase(*a.ValueType)
 	}
 	if a.DataType != nil {
 		r.DataType = *a.ValueType
@@ -167,6 +168,13 @@ func (r Reading) Validate() (bool, error) {
 		return false, NewErrContractInvalid("float encoding must be specified for float values")
 	}
 	return true, nil
+}
+
+// normalizeValueTypeCase normalize the reading's valueType to upper camel case
+func normalizeValueTypeCase(valueType string) string {
+	normalized := strings.Title(strings.ToLower(valueType))
+	normalized = strings.ReplaceAll(normalized, "array", "Array")
+	return normalized
 }
 
 // String returns a JSON encoded string representation of the model

--- a/models/reading_test.go
+++ b/models/reading_test.go
@@ -111,3 +111,24 @@ func TestCborEncoding(t *testing.T) {
 		t.Error("Failed to properly encode all reading data")
 	}
 }
+
+func TestNormalizeValueTypeCase(t *testing.T) {
+	tests := []struct {
+		name      string
+		valueType string
+		want      string
+	}{
+		{"normalize Bool value type", "bool", ValueTypeBool},
+		{"normalize Float32 value type", "FLOAT32", ValueTypeFloat32},
+		{"normalize Int64Array value type", "int64array", ValueTypeInt64Array},
+		{"normalize Float64Array value type", "FLOAT64ARRAY", ValueTypeFloat64Array},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized := normalizeValueTypeCase(tt.valueType)
+			if normalized != tt.want {
+				t.Errorf("normalized value type = %s, want %s", normalized, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since Go DS and C DS send reading with different letter cases, we should normalize the valueType to make it consistent.

Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Go DS and C DS send reading with different letter cases.

Issue Number:


## What is the new behavior?
Normalize the valueType to make it consistent.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information