### PR TITLE
EDX-889 Add a new receiving channel - ZeroMQ

### DIFF
--- a/models/channel.go
+++ b/models/channel.go
@@ -19,11 +19,13 @@ import (
 	"encoding/json"
 )
 
-// Channel supports transmissions and notifications with fields for delivery via email or REST
+// Channel supports transmissions and notifications with fields for delivery via email, REST, or ZeroMQ
 type Channel struct {
-	Type          ChannelType `json:"type,omitempty"`          // Type indicates whether the channel facilitates email or REST
+	Type          ChannelType `json:"type,omitempty"`          // Type indicates whether the channel facilitates email, REST, or ZeroMQ
 	MailAddresses []string    `json:"mailAddresses,omitempty"` // MailAddresses contains email addresses
 	Url           string      `json:"url,omitempty"`           // URL contains a REST API destination
+	Port          int         `json:"port,omitempty"`          // Port specifies the port to which the channel is bound
+	Topic         string      `json:"topic,omitempty"`         // Topic for filtering messages, usually be used by MQTT or ZeroMQ
 }
 
 func (c Channel) String() string {

--- a/models/channel_type.go
+++ b/models/channel_type.go
@@ -24,8 +24,9 @@ import (
 type ChannelType string
 
 const (
-	Rest  = "REST"
-	Email = "EMAIL"
+	Rest   = "REST"
+	Email  = "EMAIL"
+	ZeroMQ = "ZeroMQ"
 )
 
 // UnmarshalJSON implements the Unmarshaler interface for the type
@@ -36,7 +37,7 @@ func (as *ChannelType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("ChannelType should be a string, got %s", data)
 	}
 
-	got, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email}[s]
+	got, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email, "ZeroMQ": ZeroMQ}[s]
 	if !err {
 		return fmt.Errorf("invalid ChannelType %q", s)
 	}
@@ -45,7 +46,7 @@ func (as *ChannelType) UnmarshalJSON(data []byte) error {
 }
 
 func (as ChannelType) Validate() (bool, error) {
-	_, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email}[string(as)]
+	_, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email, "ZeroMQ": ZeroMQ}[string(as)]
 	if !err {
 		return false, NewErrContractInvalid(fmt.Sprintf("invalid Channeltype %q", as))
 	}

--- a/models/channel_type_test.go
+++ b/models/channel_type_test.go
@@ -20,6 +20,7 @@ import "testing"
 func TestChannelType_UnmarshalJSON(t *testing.T) {
 	var eChannelType = ChannelType(Email)
 	var rChannelType = ChannelType(Rest)
+	var zChannelType = ChannelType(ZeroMQ)
 
 	tests := []struct {
 		name    string
@@ -29,6 +30,7 @@ func TestChannelType_UnmarshalJSON(t *testing.T) {
 	}{
 		{"test unmarshal email", &eChannelType, []byte("\"EMAIL\""), false},
 		{"test unmarshal rest", &rChannelType, []byte("\"REST\""), false},
+		{"test unmarshal 0mq", &zChannelType, []byte("\"ZeroMQ\""), false},
 		{"test unmarshal error", &eChannelType, []byte("\"foo\""), true},
 	}
 	for _, tt := range tests {
@@ -43,6 +45,7 @@ func TestChannelType_UnmarshalJSON(t *testing.T) {
 func TestChannelType_Validate(t *testing.T) {
 	var eChannelType = ChannelType(Email)
 	var rChannelType = ChannelType(Rest)
+	var zChannelType = ChannelType(ZeroMQ)
 	var invalid = ChannelType("foo")
 
 	tests := []struct {
@@ -52,6 +55,7 @@ func TestChannelType_Validate(t *testing.T) {
 	}{
 		{"valid EMAIL channel", eChannelType, false},
 		{"valid REST channel", rChannelType, false},
+		{"valid ZeroMQ channel", zChannelType, false},
 		{"invalid channel type", invalid, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: EDX-889


## What is the new behavior?
A new channel type `ZeroMQ` can be used when creating/updating notification subscriptions.

Example use:
```
{
	"slug": "test-zmq",
	"receiver": "test-group",
	"subscribedCategories": [
		"SW_HEALTH"
	],
	"subscribedLabels": [
		"metadata"
    ],
	"channels": [
		{
	        	"type": "ZeroMQ",
                         "protocol": "tcp",
                         "port": 5663,
                         "topic": "notification"
		}
	]
}
```


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information