### PR TITLE
EDX-890 Add a new receiving channel - MQTT

### DIFF
--- a/models/channel.go
+++ b/models/channel.go
@@ -19,13 +19,19 @@ import (
 	"encoding/json"
 )
 
-// Channel supports transmissions and notifications with fields for delivery via email, REST, or ZeroMQ
+// Channel supports transmissions and notifications with fields for delivery via email, REST, ZeroMQ, or MQTT
 type Channel struct {
-	Type          ChannelType `json:"type,omitempty"`          // Type indicates whether the channel facilitates email, REST, or ZeroMQ
-	MailAddresses []string    `json:"mailAddresses,omitempty"` // MailAddresses contains email addresses
-	Url           string      `json:"url,omitempty"`           // URL contains a REST API destination
-	Port          int         `json:"port,omitempty"`          // Port specifies the port to which the channel is bound
-	Topic         string      `json:"topic,omitempty"`         // Topic for filtering messages, usually be used by MQTT or ZeroMQ
+	Type               ChannelType `json:"type,omitempty"`               // Type indicates whether the channel facilitates email, REST, ZeroMQ, or MQTT
+	MailAddresses      []string    `json:"mailAddresses,omitempty"`      // MailAddresses contains email addresses
+	Url                string      `json:"url,omitempty"`                // URL contains a REST API destination or message bus endpoint
+	Port               int         `json:"port,omitempty"`               // Port specifies the port to which the channel is bound
+	Topic              string      `json:"topic,omitempty"`              // Topic for filtering messages, usually be used by MQTT or ZeroMQ
+	SecretSource       string      `json:"secretSource,omitempty"`       // SecretSource indicates where to get secrets
+	SecretPath         string      `json:"secretPath,omitempty"`         // SecretPath specifies the path in the secret provider from which to retrieve secrets
+	ClientKeyFilePath  string      `json:"clientKeyFilePath,omitempty"`  // ClientKeyFilePath specifies the path of the client private key file
+	ClientCertFilePath string      `json:"clientCertFilePath,omitempty"` // ClientCertFilePath specifies the path of the client certificate file
+	ServerCaFilePath   string      `json:"serverCaFilePath,omitempty"`   // ServerCaFilePath specifies the path of the server CA certificate file
+	QoS                int         `json:"qos,omitempty"`                // QoS specifies the Quality of Service levels
 }
 
 func (c Channel) String() string {

--- a/models/channel_type.go
+++ b/models/channel_type.go
@@ -27,6 +27,7 @@ const (
 	Rest   = "REST"
 	Email  = "EMAIL"
 	ZeroMQ = "ZeroMQ"
+	MQTT   = "MQTT"
 )
 
 // UnmarshalJSON implements the Unmarshaler interface for the type
@@ -37,7 +38,7 @@ func (as *ChannelType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("ChannelType should be a string, got %s", data)
 	}
 
-	got, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email, "ZeroMQ": ZeroMQ}[s]
+	got, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email, "ZeroMQ": ZeroMQ, "MQTT": MQTT}[s]
 	if !err {
 		return fmt.Errorf("invalid ChannelType %q", s)
 	}
@@ -46,7 +47,7 @@ func (as *ChannelType) UnmarshalJSON(data []byte) error {
 }
 
 func (as ChannelType) Validate() (bool, error) {
-	_, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email, "ZeroMQ": ZeroMQ}[string(as)]
+	_, err := map[string]ChannelType{"REST": Rest, "EMAIL": Email, "ZeroMQ": ZeroMQ, "MQTT": MQTT}[string(as)]
 	if !err {
 		return false, NewErrContractInvalid(fmt.Sprintf("invalid Channeltype %q", as))
 	}

--- a/models/channel_type_test.go
+++ b/models/channel_type_test.go
@@ -21,6 +21,7 @@ func TestChannelType_UnmarshalJSON(t *testing.T) {
 	var eChannelType = ChannelType(Email)
 	var rChannelType = ChannelType(Rest)
 	var zChannelType = ChannelType(ZeroMQ)
+	var mChannelType = ChannelType(MQTT)
 
 	tests := []struct {
 		name    string
@@ -31,6 +32,7 @@ func TestChannelType_UnmarshalJSON(t *testing.T) {
 		{"test unmarshal email", &eChannelType, []byte("\"EMAIL\""), false},
 		{"test unmarshal rest", &rChannelType, []byte("\"REST\""), false},
 		{"test unmarshal 0mq", &zChannelType, []byte("\"ZeroMQ\""), false},
+		{"test unmarshal mqtt", &mChannelType, []byte("\"MQTT\""), false},
 		{"test unmarshal error", &eChannelType, []byte("\"foo\""), true},
 	}
 	for _, tt := range tests {
@@ -46,6 +48,7 @@ func TestChannelType_Validate(t *testing.T) {
 	var eChannelType = ChannelType(Email)
 	var rChannelType = ChannelType(Rest)
 	var zChannelType = ChannelType(ZeroMQ)
+	var mChannelType = ChannelType(MQTT)
 	var invalid = ChannelType("foo")
 
 	tests := []struct {
@@ -56,6 +59,7 @@ func TestChannelType_Validate(t *testing.T) {
 		{"valid EMAIL channel", eChannelType, false},
 		{"valid REST channel", rChannelType, false},
 		{"valid ZeroMQ channel", zChannelType, false},
+		{"valid MQTT channel", mChannelType, false},
 		{"invalid channel type", invalid, true},
 	}
 	for _, tt := range tests {

--- a/models/constants.go
+++ b/models/constants.go
@@ -14,15 +14,23 @@
 
 package models
 
-// These constants are used by the unit tests in the models.
 const (
+	// These constants are used by the unit tests in the models.
 	// common
 	testEmptyJSON = "{}"
-
 	// action
 	testCode           = "200"
 	testDescription    = "ok"
 	testExpectedvalue1 = "temperature"
 	testExpectedvalue2 = "humidity"
 	testActionPath     = "test/path"
+
+	// These constants are the valid values of SecretSource variable of Channel struct
+	SecretSourceSecretStore = "secretstore"
+	SecretSourceFile        = "file"
+
+	// These constants are the default names of secret keys in the secret store
+	SecretKeyCertificate = "cert"
+	SecretKeyPrivateKey  = "key"
+	SecretKeyCA          = "ca"
 )


### PR DESCRIPTION
Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: EDX-890


## What is the new behavior?
A new channel type MQTT can be used when creating/updating notification subscriptions.

Example Use:
Case 1: secretSource = `secretstore`
```
{
	"slug": "test-mqtt",
	"receiver": "test-group",
	"subscribedCategories": [
		"DEVICE_CHANGED"
	],
	"subscribedLabels": [
		"metadata"
	],
	"channels": [
		{
			"type": "MQTT",
			"url": "tls://test.mosquitto.org:8884",
			"topic": "iotech/notification/devicechanged",
			"secretSource": "secretstore",
			"secretPath": "mosquitto",
			"qos": 0
		}
	]
}
```
Case 2: secretSource = `file`
```
{
	"slug": "test-mqtt",
	"receiver": "test-group",
	"subscribedCategories": [
		"DEVICE_CHANGED"
	],
	"subscribedLabels": [
		"metadata"
	],
	"channels": [
		{
			"type": "MQTT",
			"url": "tls://test.mosquitto.org:8884",
			"topic": "iotech/notification/devicechanged",
			"secretSource": "file",
			"clientKeyFilePath": "/etc/edgexpert/secrets/test/client.key",
			"clientCertFilePath": "/etc/edgexpert/secrets/test/client.crt",
			"serverCaFilePath": "/etc/edgexpert/secrets/test/ca.crt",
			"qos": 0
		}
	]
}
```
Case 3: any secrets are not required, i.e. the MQTT connection uses `tcp` protocol
```
{
	"slug": "test-mqtt",
	"receiver": "test-group",
	"subscribedCategories": [
		"DEVICE_CHANGED"
	],
	"subscribedLabels": [
		"metadata"
	],
	"channels": [
		{
			"type": "MQTT",
			"url": "tcp://test.mosquitto.org:1883",
			"topic": "iotech/notification/devicechanged",
			"qos": 0
		}
	]
}
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information