### PR TITLE
EDX-1185 Change the type of MaxRetentionEvents/MaxBatchEvents from uint to uint32

### DIFF
--- a/models/registration.go
+++ b/models/registration.go
@@ -81,8 +81,8 @@ type Registration struct {
 	Enable             bool              `json:"enable"`
 	Destination        string            `json:"destination,omitempty"`
 	ProcessFrequency   string            `json:"processFrequency,omitempty"`
-	MaxRetentionEvents uint              `json:"maxRetentionEvents,omitempty"`
-	MaxBatchEvents     uint              `json:"maxBatchEvents,omitempty"`
+	MaxRetentionEvents uint32            `json:"maxRetentionEvents,omitempty"`
+	MaxBatchEvents     uint32            `json:"maxBatchEvents,omitempty"`
 	NeedDataType       bool              `json:"needDataType,omitempty"`
 	isValidated        bool              // internal member used for validation check
 }
@@ -104,8 +104,8 @@ func (r *Registration) UnmarshalJSON(data []byte) error {
 		Enable             bool              `json:"enable"`
 		Destination        *string           `json:"destination"`
 		ProcessFrequency   string            `json:"processFrequency"`
-		MaxRetentionEvents uint              `json:"maxRetentionEvents"`
-		MaxBatchEvents     uint              `json:"maxBatchEvents"`
+		MaxRetentionEvents uint32            `json:"maxRetentionEvents"`
+		MaxBatchEvents     uint32            `json:"maxBatchEvents"`
 		NeedDataType       bool              `json:"needDataType"`
 	}
 	a := Alias{}

--- a/models/registration_test.go
+++ b/models/registration_test.go
@@ -93,12 +93,14 @@ func TestMaxRetentionEvents(t *testing.T) {
 	tests := []struct {
 		name        string
 		data        string
-		expectValue uint
+		expectValue uint32
 		expectError bool
 	}{
 		{"invalid MaxRetentionEvents: string", "{\"maxRetentionEvents\":\"s\"}",
 			DefaultMaxRetentionEvents, true},
 		{"invalid MaxRetentionEvents: negative number", "{\"maxRetentionEvents\":-1}",
+			DefaultMaxRetentionEvents, true},
+		{"invalid MaxRetentionEvents: out of range", "{\"maxRetentionEvents\":4294967296}",
 			DefaultMaxRetentionEvents, true},
 		{"invalid MaxRetentionEvents: float", "{\"maxRetentionEvents\":3.1415}",
 			DefaultMaxRetentionEvents, true},
@@ -136,6 +138,7 @@ func TestMaxBatchEvents(t *testing.T) {
 	}{
 		{"invalid MaxBatchEvents: string", "{\"maxRetentionEvents\":\"s\"}", true},
 		{"invalid MaxBatchEvents: negative number", "{\"maxRetentionEvents\":-1}", true},
+		{"invalid MaxBatchEvents: out of range", "{\"maxRetentionEvents\":4294967296}", true},
 		{"invalid MaxBatchEvents: float", "{\"maxRetentionEvents\":3.1415}", true},
 		{"normal case", "{\"maxBatchEvents\":100}", false},
 	}


### PR DESCRIPTION
To avoid overflow in arm32 system. In addition, the maximum value of uint32 is enough for MaxRetentionEvents and MaxBatchEvents.

Signed-off-by: Felix Ting <felix@iotechsys.com>
