### PR TITLE
EDX-1260 Set FloatEncoding to eNotation by default

### DIFF
--- a/models/addressable.go
+++ b/models/addressable.go
@@ -34,8 +34,8 @@ type Addressable struct {
 	User        string `json:"user,omitempty"`        // User id for authentication
 	Password    string `json:"password,omitempty"`    // Password of the user for authentication for the addressable
 	Topic       string `json:"topic,omitempty"`       // Topic for message bus addressables
-	Cert        string `json:"cert,omitempty"` // Path to the Certificate file for authentication
-	Key         string `json:"key,omitempty"`  // Path to The Private key file for authentication
+	Cert        string `json:"cert,omitempty"`        // Path to the Certificate file for authentication
+	Key         string `json:"key,omitempty"`         // Path to The Private key file for authentication
 	isValidated bool   // internal member used for validation check
 }
 

--- a/models/addressable_test.go
+++ b/models/addressable_test.go
@@ -32,8 +32,8 @@ const (
 	testUser      = "edgexer"
 	testPassword  = "password"
 	testTopic     = "device_topic"
-	testCert = "/export/keys/mycert.pem.crt"
-	testKey = "/export/keys/myprivatekey.pem.key"
+	testCert      = "/export/keys/mycert.pem.crt"
+	testKey       = "/export/keys/myprivatekey.pem.key"
 )
 
 var TestAddressable = Addressable{Timestamps: testTimestamps, Name: testAddrName, Protocol: testProtocol, HTTPMethod: testMethod, Address: testAddress, Port: testPort, Path: clients.ApiDeviceRoute, Publisher: testPublisher, User: testUser, Password: testPassword, Topic: testTopic, Cert: testCert, Key: testKey}

--- a/models/reading.go
+++ b/models/reading.go
@@ -135,6 +135,10 @@ func (r *Reading) UnmarshalJSON(data []byte) error {
 	r.Modified = a.Modified
 	r.BinaryValue = a.BinaryValue
 
+	if (r.ValueType == ValueTypeFloat32 || r.ValueType == ValueTypeFloat64) && r.FloatEncoding != Base64Encoding {
+		r.FloatEncoding = ENotation
+	}
+
 	r.isValidated, err = r.Validate()
 	return err
 }
@@ -164,9 +168,6 @@ func (r Reading) Validate() (bool, error) {
 		return false, NewErrContractInvalid("media type must be specified for binary values")
 	}
 
-	if (r.ValueType == ValueTypeFloat32 || r.ValueType == ValueTypeFloat64) && len(r.FloatEncoding) == 0 {
-		return false, NewErrContractInvalid("float encoding must be specified for float values")
-	}
 	return true, nil
 }
 

--- a/models/reading_test.go
+++ b/models/reading_test.go
@@ -79,8 +79,6 @@ func TestReadingValidation(t *testing.T) {
 		{"missing value", Reading{Device: "test", Name: "test"}, true},
 		{"missing media type", Reading{Name: "test", BinaryValue: TestBinaryValue}, true},
 		{"media type present", Reading{Name: "test", Value: "test", MediaType: TestMediaType}, false},
-		{"missing float encoding f64", Reading{Name: "test", ValueType: ValueTypeFloat64, Value: "3.14"}, true},
-		{"missing float encoding f32", Reading{Name: "test", ValueType: ValueTypeFloat32, Value: "3.14"}, true},
 		{"valid float f64", Reading{Name: "test", ValueType: ValueTypeFloat64, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
 		{"valid float f32", Reading{Name: "test", ValueType: ValueTypeFloat32, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
 		{"valid empty binary value", Reading{Name: "test", ValueType: ValueTypeBinary}, false},


### PR DESCRIPTION
If reading's value type is float and FloatEncoding is not specified, set FloatEncoding to eNotation by default.

Also fix the format issue of addressable.go and addressable_test.go

Signed-off-by: Felix Ting <felix@iotechsys.com>