### PR TITLE
EDX-1260-2 Set FloatEncoding to eNotation by default

### DIFF
--- a/models/reading.go
+++ b/models/reading.go
@@ -135,6 +135,10 @@ func (r *Reading) UnmarshalJSON(data []byte) error {
 	r.Modified = a.Modified
 	r.BinaryValue = a.BinaryValue
 
+	if (r.ValueType == ValueTypeFloat32 || r.ValueType == ValueTypeFloat64) && r.FloatEncoding != Base64Encoding {
+		r.FloatEncoding = ENotation
+	}
+
 	r.isValidated, err = r.Validate()
 	return err
 }
@@ -164,9 +168,6 @@ func (r Reading) Validate() (bool, error) {
 		return false, NewErrContractInvalid("media type must be specified for binary values")
 	}
 
-	if (r.ValueType == ValueTypeFloat32 || r.ValueType == ValueTypeFloat64) && len(r.FloatEncoding) == 0 {
-		return false, NewErrContractInvalid("float encoding must be specified for float values")
-	}
 	return true, nil
 }
 


### PR DESCRIPTION
If reading's value type is float and FloatEncoding is not Base64, set FloatEncoding to eNotation by default.

Signed-off-by: Felix Ting <felix@iotechsys.com>
