### PR TITLE
PS-166 Upate event tags from map[string]string to map[string]interface{}

### DIFF
--- a/models/event.go
+++ b/models/event.go
@@ -25,16 +25,16 @@ import (
 
 // Event represents a single measurable event read from a device
 type Event struct {
-	ID          string            `json:"id,omitempty" codec:"id,omitempty"`             // ID uniquely identifies an event, for example a UUID
-	Pushed      int64             `json:"pushed,omitempty" codec:"pushed,omitempty"`     // Pushed is a timestamp indicating when the event was exported. If unexported, the value is zero.
-	Device      string            `json:"device,omitempty" codec:"device,omitempty"`     // Device identifies the source of the event, can be a device name or id. Usually the device name.
-	Created     int64             `json:"created,omitempty" codec:"created,omitempty"`   // Created is a timestamp indicating when the event was created.
-	Modified    int64             `json:"modified,omitempty" codec:"modified,omitempty"` // Modified is a timestamp indicating when the event was last modified.
-	Origin      int64             `json:"origin,omitempty" codec:"origin,omitempty"`     // Origin is a timestamp that can communicate the time of the original reading, prior to event creation
-	Readings    []Reading         `json:"readings,omitempty" codec:"readings,omitempty"` // Readings will contain zero to many entries for the associated readings of a given event.
-	Tags        map[string]string `json:"tags,omitempty" codec:"tags,omitempty" xml:"-"` // Tags is an optional collection of key/value pairs that all the event to be tagged with custom information. Ignored for XML since maps not supported.
-	isValidated bool              // internal member used for validation check
-	CommandName string            `json:"commandName,omitempty" codec:"commandName,omitempty"`
+	ID          string                 `json:"id,omitempty" codec:"id,omitempty"`             // ID uniquely identifies an event, for example a UUID
+	Pushed      int64                  `json:"pushed,omitempty" codec:"pushed,omitempty"`     // Pushed is a timestamp indicating when the event was exported. If unexported, the value is zero.
+	Device      string                 `json:"device,omitempty" codec:"device,omitempty"`     // Device identifies the source of the event, can be a device name or id. Usually the device name.
+	Created     int64                  `json:"created,omitempty" codec:"created,omitempty"`   // Created is a timestamp indicating when the event was created.
+	Modified    int64                  `json:"modified,omitempty" codec:"modified,omitempty"` // Modified is a timestamp indicating when the event was last modified.
+	Origin      int64                  `json:"origin,omitempty" codec:"origin,omitempty"`     // Origin is a timestamp that can communicate the time of the original reading, prior to event creation
+	Readings    []Reading              `json:"readings,omitempty" codec:"readings,omitempty"` // Readings will contain zero to many entries for the associated readings of a given event.
+	Tags        map[string]interface{} `json:"tags,omitempty" codec:"tags,omitempty" xml:"-"` // Tags is an optional collection of key/value pairs that all the event to be tagged with custom information. Ignored for XML since maps not supported.
+	isValidated bool                   // internal member used for validation check
+	CommandName string                 `json:"commandName,omitempty" codec:"commandName,omitempty"`
 }
 
 func encodeAsCBOR(e Event) ([]byte, error) {
@@ -50,15 +50,15 @@ func encodeAsCBOR(e Event) ([]byte, error) {
 func (e *Event) UnmarshalJSON(data []byte) error {
 	var err error
 	type Alias struct {
-		ID          *string           `json:"id"`
-		Pushed      int64             `json:"pushed"`
-		Device      *string           `json:"device"`
-		Created     int64             `json:"created"`
-		Modified    int64             `json:"modified"`
-		Origin      int64             `json:"origin"`
-		Readings    []Reading         `json:"readings"`
-		Tags        map[string]string `json:"tags"`
-		CommandName *string           `json:"commandName"`
+		ID          *string                `json:"id"`
+		Pushed      int64                  `json:"pushed"`
+		Device      *string                `json:"device"`
+		Created     int64                  `json:"created"`
+		Modified    int64                  `json:"modified"`
+		Origin      int64                  `json:"origin"`
+		Readings    []Reading              `json:"readings"`
+		Tags        map[string]interface{} `json:"tags"`
+		CommandName *string                `json:"commandName"`
 	}
 	a := Alias{}
 

--- a/models/event_test.go
+++ b/models/event_test.go
@@ -32,7 +32,7 @@ var TestEvent = Event{
 	Origin:   123,
 	Modified: 123,
 	Readings: []Reading{TestReading},
-	Tags: map[string]string{
+	Tags: map[string]interface{}{
 		"GatewayID": "Houston-0001",
 		"Latitude":  "29.630771",
 		"Longitude": "-95.377603",


### PR DESCRIPTION
There are more and more requirements that needs to tag a json object
instead of json string into the event.  PMY bus scenario is one among
these requirements.  This commit updates the event struct from
map[string]string tag to map[string]interface{}.

Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information