### PR TITLE
fix: Adding the missed PATCH method in REST Address DTO

### DIFF
--- a/dtos/address.go
+++ b/dtos/address.go
@@ -68,7 +68,7 @@ func (a *Address) Validate() error {
 
 type RESTAddress struct {
 	Path       string `json:"path,omitempty"`
-	HTTPMethod string `json:"httpMethod,omitempty" validate:"required,oneof='GET' 'HEAD' 'POST' 'PUT' 'DELETE' 'TRACE' 'CONNECT'"`
+	HTTPMethod string `json:"httpMethod,omitempty" validate:"required,oneof='GET' 'HEAD' 'POST' 'PUT' 'PATCH' 'DELETE' 'TRACE' 'CONNECT'"`
 }
 
 func NewRESTAddress(host string, port int, httpMethod string) Address {

--- a/dtos/address_test.go
+++ b/dtos/address_test.go
@@ -8,6 +8,7 @@ package dtos
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
@@ -106,6 +107,8 @@ func TestAddress_UnmarshalJSON(t *testing.T) {
 
 func TestAddress_Validate(t *testing.T) {
 	validRest := testRESTAddress
+	validRestPatch := testRESTAddress
+	validRestPatch.HTTPMethod = http.MethodPatch
 	noRestHttpMethod := testRESTAddress
 	noRestHttpMethod.HTTPMethod = ""
 
@@ -125,6 +128,7 @@ func TestAddress_Validate(t *testing.T) {
 		expectError bool
 	}{
 		{"valid RESTAddress", validRest, false},
+		{"valid RESTAddress, PATCH http method", validRestPatch, false},
 		{"invalid RESTAddress, no HTTP method", noRestHttpMethod, true},
 		{"valid MQTTPubAddress", validMQTT, false},
 		{"invalid MQTTPubAddress, no MQTT publisher", noMQTTPublisher, true},


### PR DESCRIPTION
> Adding the PATCH method to Address DTO validate tag

Pick the community changes to this repo. 
https://github.com/edgexfoundry/go-mod-core-contracts/pull/686