### PR TITLE
EDX-2347 Add apiVersion in Device Profile for Xpert

### DIFF
--- a/dtos/deviceprofile.go
+++ b/dtos/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,6 +18,7 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.1.0#/DeviceProfile
 type DeviceProfile struct {
 	DBTimestamp     `json:",inline" yaml:"dbTimestamp,omitempty"`
+	ApiVersion      string           `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 	Id              string           `json:"id,omitempty" validate:"omitempty,uuid" yaml:"id,omitempty"`
 	Name            string           `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Manufacturer    string           `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
@@ -41,6 +42,7 @@ func (dp *DeviceProfile) Validate() error {
 func (dp *DeviceProfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var alias struct {
 		DBTimestamp
+		ApiVersion      string           `yaml:"apiVersion"`
 		Id              string           `yaml:"id"`
 		Name            string           `yaml:"name"`
 		Manufacturer    string           `yaml:"manufacturer"`
@@ -74,6 +76,7 @@ func (dp *DeviceProfile) UnmarshalYAML(unmarshal func(interface{}) error) error 
 func ToDeviceProfileModel(deviceProfileDTO DeviceProfile) models.DeviceProfile {
 	return models.DeviceProfile{
 		DBTimestamp:     models.DBTimestamp(deviceProfileDTO.DBTimestamp),
+		ApiVersion:      deviceProfileDTO.ApiVersion,
 		Id:              deviceProfileDTO.Id,
 		Name:            deviceProfileDTO.Name,
 		Description:     deviceProfileDTO.Description,
@@ -89,6 +92,7 @@ func ToDeviceProfileModel(deviceProfileDTO DeviceProfile) models.DeviceProfile {
 func FromDeviceProfileModelToDTO(deviceProfile models.DeviceProfile) DeviceProfile {
 	return DeviceProfile{
 		DBTimestamp:     DBTimestamp(deviceProfile.DBTimestamp),
+		ApiVersion:      deviceProfile.ApiVersion,
 		Id:              deviceProfile.Id,
 		Name:            deviceProfile.Name,
 		Description:     deviceProfile.Description,

--- a/dtos/deviceprofile_test.go
+++ b/dtos/deviceprofile_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,6 +23,7 @@ var testAttributes = map[string]interface{}{
 var testMappings = map[string]string{"0": "off", "1": "on"}
 
 var testDeviceProfile = models.DeviceProfile{
+	ApiVersion:   common.ApiVersion,
 	Name:         TestDeviceProfileName,
 	Manufacturer: TestManufacturer,
 	Description:  TestDescription,
@@ -50,6 +51,7 @@ var testDeviceProfile = models.DeviceProfile{
 
 func profileData() DeviceProfile {
 	return DeviceProfile{
+		ApiVersion:   common.ApiVersion,
 		Name:         TestDeviceProfileName,
 		Manufacturer: TestManufacturer,
 		Description:  TestDescription,

--- a/dtos/requests/deviceprofile_test.go
+++ b/dtos/requests/deviceprofile_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -48,6 +48,7 @@ func profileData() DeviceProfileRequest {
 			Versionable: dtoCommon.NewVersionable(),
 		},
 		Profile: dtos.DeviceProfile{
+			ApiVersion:      common.ApiVersion,
 			Name:            TestDeviceProfileName,
 			Manufacturer:    TestManufacturer,
 			Description:     TestDescription,
@@ -60,6 +61,7 @@ func profileData() DeviceProfileRequest {
 }
 
 var expectedDeviceProfile = models.DeviceProfile{
+	ApiVersion:   common.ApiVersion,
 	Name:         TestDeviceProfileName,
 	Manufacturer: TestManufacturer,
 	Description:  TestDescription,

--- a/models/deviceprofile.go
+++ b/models/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,7 @@ package models
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type DeviceProfile struct {
 	DBTimestamp
+	ApiVersion      string
 	Description     string
 	Id              string
 	Name            string

--- a/v1models/transform.go
+++ b/v1models/transform.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2022 IOTech Ltd
 
 package v1models
 
@@ -253,6 +253,7 @@ func TransformProfileFromV1ToV2(profile DeviceProfile) (models.DeviceProfile, er
 	}
 
 	v2dp := models.DeviceProfile{
+		ApiVersion:   common.ApiVersion,
 		Description:  profile.Description,
 		Name:         profile.Name,
 		Manufacturer: profile.Manufacturer,

--- a/v1models/transform_test.go
+++ b/v1models/transform_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2022 IOTech Ltd
 
 package v1models
 
@@ -270,6 +270,7 @@ func v2ProfileData() v2Model.DeviceProfile {
 		},
 	}}
 	return v2Model.DeviceProfile{
+		ApiVersion:   common.ApiVersion,
 		Name:         TestProfileName,
 		Manufacturer: TestManufacturer,
 		Model:        TestModel,


### PR DESCRIPTION
XRT will support v2 profile, but it needs `apiVersion` fieldhttps://iotechsys.atlassian.net/wiki/spaces/EN/pages/3081306123/XRT+V2+SDK+Device+Service+Update+Tips

We should add to DTO and model, and will use in xrt-bridge
