### PR TITLE
EDX-2385 Convert protocolName to lowerCase when transferring to model

### DIFF
--- a/dtos/device.go
+++ b/dtos/device.go
@@ -1,11 +1,13 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package dtos
 
 import (
+	"strings"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
@@ -66,7 +68,7 @@ func ToDeviceModel(dto Device) models.Device {
 	d.Labels = dto.Labels
 	d.Location = dto.Location
 	d.AutoEvents = ToAutoEventModels(dto.AutoEvents)
-	d.ProtocolName = dto.ProtocolName
+	d.ProtocolName = strings.ToLower(dto.ProtocolName)
 	d.Protocols = ToProtocolModels(dto.Protocols)
 	d.Properties = dto.Properties
 	return d

--- a/dtos/requests/device_test.go
+++ b/dtos/requests/device_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,6 +28,7 @@ var testAutoEvents = []dtos.AutoEvent{
 var testAutoEventsWithInvalidFrequency = []dtos.AutoEvent{
 	{SourceName: "TestDevice", Interval: "300", OnChange: true},
 }
+var testProtocolName = "Modbus-IP"
 var testProtocols = map[string]dtos.ProtocolProperties{
 	"modbus-ip": {
 		"Address": "localhost",
@@ -49,6 +50,7 @@ var testAddDevice = AddDeviceRequest{
 		Labels:         testDeviceLabels,
 		Location:       testDeviceLocation,
 		AutoEvents:     testAutoEvents,
+		ProtocolName:   testProtocolName,
 		Protocols:      testProtocols,
 	},
 }
@@ -228,6 +230,7 @@ func Test_AddDeviceReqToDeviceModels(t *testing.T) {
 			AutoEvents: []models.AutoEvent{
 				{SourceName: "TestDevice", Interval: "300ms", OnChange: true},
 			},
+			ProtocolName: "modbus-ip",
 			Protocols: map[string]models.ProtocolProperties{
 				"modbus-ip": {
 					"Address": "localhost",


### PR DESCRIPTION
GUI always assumes protocolName is lowerCase, so we should handle the case sensitive issue before storing to the database

Signed-off-by: bruce <weichou1229@gmail.com>
