### PR TITLE
EDX-2632 cherry pick - Update the ReadWrite validation to include WR

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -246,6 +246,7 @@ const (
 	ReadWrite_R  = "R"
 	ReadWrite_W  = "W"
 	ReadWrite_RW = "RW"
+	ReadWrite_WR = "WR"
 )
 
 // Constants for Edgex Environment variable

--- a/dtos/devicecommand.go
+++ b/dtos/devicecommand.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +12,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 type DeviceCommand struct {
 	Name               string              `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	IsHidden           bool                `json:"isHidden" yaml:"isHidden"`
-	ReadWrite          string              `json:"readWrite" yaml:"readWrite" validate:"required,oneof='R' 'W' 'RW'"`
+	ReadWrite          string              `json:"readWrite" yaml:"readWrite" validate:"required,oneof='R' 'W' 'RW' 'WR'"`
 	ResourceOperations []ResourceOperation `json:"resourceOperations" yaml:"resourceOperations" validate:"gt=0,dive"`
 }
 

--- a/dtos/deviceprofile.go
+++ b/dtos/deviceprofile.go
@@ -157,7 +157,7 @@ func validReadWritePermission(resources []DeviceResource, name string, readWrite
 	valid := true
 	for _, resource := range resources {
 		if resource.Name == name {
-			if resource.Properties.ReadWrite != common.ReadWrite_RW &&
+			if resource.Properties.ReadWrite != common.ReadWrite_RW && resource.Properties.ReadWrite != common.ReadWrite_WR &&
 				resource.Properties.ReadWrite != readWrite {
 				valid = false
 				break

--- a/dtos/requests/deviceprofile_test.go
+++ b/dtos/requests/deviceprofile_test.go
@@ -105,6 +105,8 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 	noDeviceResourceReadWrite.Profile.DeviceResources[0].Properties.ReadWrite = emptyString
 	invalidDeviceResourceReadWrite := profileData()
 	invalidDeviceResourceReadWrite.Profile.DeviceResources[0].Properties.ReadWrite = "invalid"
+	validDeviceResourceReadWrite := profileData()
+	validDeviceResourceReadWrite.Profile.DeviceResources[0].Properties.ReadWrite = common.ReadWrite_WR
 
 	tests := []struct {
 		name          string
@@ -119,6 +121,7 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 		{"invalid DeviceProfileRequest, invalid deviceResource property type", invalidDeviceResourcePropertyType, true},
 		{"invalid DeviceProfileRequest, no deviceResource property readWrite", noDeviceResourceReadWrite, true},
 		{"invalid DeviceProfileRequest, invalid deviceResource property readWrite", invalidDeviceResourcePropertyType, true},
+		{"valid DeviceProfileRequest, valid deviceResource property readWrite with value WR", validDeviceResourceReadWrite, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dtos/resourceproperties.go
+++ b/dtos/resourceproperties.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.1.0#/ResourceProperties
 type ResourceProperties struct {
 	ValueType    string `json:"valueType" yaml:"valueType" validate:"required,edgex-dto-value-type"`
-	ReadWrite    string `json:"readWrite" yaml:"readWrite" validate:"required,oneof='R' 'W' 'RW'"`
+	ReadWrite    string `json:"readWrite" yaml:"readWrite" validate:"required,oneof='R' 'W' 'RW' 'WR'"`
 	Units        string `json:"units,omitempty" yaml:"units,omitempty"`
 	Minimum      string `json:"minimum,omitempty" yaml:"minimum,omitempty"`
 	Maximum      string `json:"maximum,omitempty" yaml:"maximum,omitempty"`


### PR DESCRIPTION
Cherry pick from community [commit](https://github.com/edgexfoundry/go-mod-core-contracts/commit/b3917be5ab0aa2c013b1cae3b52349178916ea57).

fix: Update the ReadWrite validation to include WR

Update the ReadWrite validation to include 'WR' value.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>