### PR TITLE
EDX-2700 Add omitempty to tag of DeviceResource dto

### DIFF
--- a/dtos/deviceresource.go
+++ b/dtos/deviceresource.go
@@ -17,7 +17,7 @@ type DeviceResource struct {
 	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
 	Name        string                 `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	IsHidden    bool                   `json:"isHidden" yaml:"isHidden"`
-	Tag         string                 `json:"tag" yaml:"tag"`
+	Tag         string                 `json:"tag,omitempty" yaml:"tag,omitempty"`
 	Tags        map[string]interface{} `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Properties  ResourceProperties     `json:"properties" yaml:"properties"`
 	Attributes  map[string]interface{} `json:"attributes,omitempty" yaml:"attributes,omitempty"`


### PR DESCRIPTION
[Issue link](https://iotechsys.atlassian.net/browse/EDX-2700)
Add omitempty attribute to tag field of DeviceResource dto.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->