### PR TITLE
EDX-2653 Allow Semicolon and Equal sign as unreserved characters

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -32,7 +32,7 @@ const (
 const (
 	// Per https://tools.ietf.org/html/rfc3986#section-2.3, unreserved characters= ALPHA / DIGIT / "-" / "." / "_" / "~"
 	// Also due to names used in topics for Redis Pub/Sub, "."are not allowed
-	rFC3986UnreservedCharsRegexString = "^[a-zA-Z0-9-_~:]+$"
+	rFC3986UnreservedCharsRegexString = "^[a-zA-Z0-9-_~:;=]+$"
 	intervalDatetimeLayout            = "20060102T150405"
 	name                              = "Name"
 )
@@ -93,7 +93,7 @@ func getErrorMessage(e validator.FieldError) string {
 	case dtoNoneEmptyStringTag:
 		msg = fmt.Sprintf("%s field should not be empty string", fieldName)
 	case dtoRFC3986UnreservedCharTag:
-		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~", fieldName)
+		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~:;=", fieldName)
 	default:
 		msg = fmt.Sprintf("%s field validation failed on the %s tag", fieldName, tag)
 	}


### PR DESCRIPTION
Allow Semicolon and Equal sign as unreserved characters for XRT v2

Signed-off-by: bruce <weichou1229@gmail.com>