### PR TITLE
EDX-2727 Remove JSON omitempty from SimpleReading value

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -34,7 +34,7 @@ type BaseReading struct {
 // SimpleReading and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.1.0#/SimpleReading
 type SimpleReading struct {
-	Value string `json:"value,omitempty" validate:"required"`
+	Value string `json:"value" validate:"required"`
 }
 
 // BinaryReading and its properties are defined in the APIv2 specification:


### PR DESCRIPTION
The SimpleReading can contain the empty string.

Signed-off-by: bruce <weichou1229@gmail.com>