### PR TITLE
EDX-2690-2 Add constant EnvMessageBusMqttTls

### DIFF
--- a/common/tls.go
+++ b/common/tls.go
@@ -30,6 +30,7 @@ const (
 	// MQTT specific settings
 	MqttClientKeyFileName  = "mqtt.key"
 	MqttClientCertFileName = "mqtt.crt"
+	EnvMessageBusMqttTls   = "MESSAGEBUS_MQTT_TLS"
 )
 
 // CreateRedisTlsConfig loads TLS certificates from specified path and creates Redis TLS config


### PR DESCRIPTION
This constant is required by edgex-go-private and xrt-xpert-bridge.

Signed-off-by: Felix Ting <felix@iotechsys.com>
