### PR TITLE
EDX-2807 Add ProtocolName to ProvisionWatcher

### DIFF
--- a/dtos/provisionwatcher.go
+++ b/dtos/provisionwatcher.go
@@ -22,6 +22,7 @@ type ProvisionWatcher struct {
 	ServiceName         string              `json:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState          string              `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents          []AutoEvent         `json:"autoEvents,omitempty" validate:"dive"`
+	ProtocolName        string              `json:"protocolName" validate:"omitempty,edgex-dto-rfc3986-unreserved-chars"`
 }
 
 // UpdateProvisionWatcher and its properties are defined in the APIv2 specification:
@@ -36,6 +37,7 @@ type UpdateProvisionWatcher struct {
 	ServiceName         *string             `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState          *string             `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents          []AutoEvent         `json:"autoEvents" validate:"dive"`
+	ProtocolName        *string             `json:"protocolName" validate:"omitempty,edgex-dto-rfc3986-unreserved-chars"`
 }
 
 // ToProvisionWatcherModel transforms the ProvisionWatcher DTO to the ProvisionWatcher model
@@ -51,6 +53,7 @@ func ToProvisionWatcherModel(dto ProvisionWatcher) models.ProvisionWatcher {
 		ServiceName:         dto.ServiceName,
 		AdminState:          models.AdminState(dto.AdminState),
 		AutoEvents:          ToAutoEventModels(dto.AutoEvents),
+		ProtocolName:        dto.ProtocolName,
 	}
 }
 
@@ -67,6 +70,7 @@ func FromProvisionWatcherModelToDTO(pw models.ProvisionWatcher) ProvisionWatcher
 		ServiceName:         pw.ServiceName,
 		AdminState:          string(pw.AdminState),
 		AutoEvents:          FromAutoEventModelsToDTOs(pw.AutoEvents),
+		ProtocolName:        pw.ProtocolName,
 	}
 }
 
@@ -83,6 +87,7 @@ func FromProvisionWatcherModelToUpdateDTO(pw models.ProvisionWatcher) UpdateProv
 		Labels:              pw.Labels,
 		Identifiers:         pw.Identifiers,
 		BlockingIdentifiers: pw.BlockingIdentifiers,
+		ProtocolName:        &pw.ProtocolName,
 	}
 	return dto
 }

--- a/dtos/provisionwatcher_test.go
+++ b/dtos/provisionwatcher_test.go
@@ -24,4 +24,5 @@ func TestFromProvisionWatcherModelToUpdateDTO(t *testing.T) {
 	assert.Equal(t, model.ProfileName, *dto.ProfileName)
 	assert.Equal(t, model.ServiceName, *dto.ServiceName)
 	assert.EqualValues(t, model.AdminState, *dto.AdminState)
+	assert.EqualValues(t, model.ProtocolName, *dto.ProtocolName)
 }

--- a/dtos/requests/provisionwatcher.go
+++ b/dtos/requests/provisionwatcher.go
@@ -113,6 +113,9 @@ func ReplaceProvisionWatcherModelFieldsWithDTO(pw *models.ProvisionWatcher, patc
 	if patch.AutoEvents != nil {
 		pw.AutoEvents = dtos.ToAutoEventModels(patch.AutoEvents)
 	}
+	if patch.ProtocolName != nil {
+		pw.ProtocolName = *patch.ProtocolName
+	}
 }
 
 func NewAddProvisionWatcherRequest(dto dtos.ProvisionWatcher) AddProvisionWatcherRequest {

--- a/dtos/requests/provisionwatcher_test.go
+++ b/dtos/requests/provisionwatcher_test.go
@@ -68,6 +68,7 @@ func mockUpdateProvisionWatcher() dtos.UpdateProvisionWatcher {
 	d.ProfileName = &testProfileName
 	d.AdminState = &testAdminState
 	d.AutoEvents = testAutoEvents
+	d.ProtocolName = &testProtocolName
 	return d
 }
 
@@ -340,4 +341,5 @@ func TestReplaceProvisionWatcherModelFieldsWithDTO(t *testing.T) {
 	assert.Equal(t, TestDeviceProfileName, provisionWatcher.ProfileName)
 	assert.Equal(t, models.AdminState(models.Locked), provisionWatcher.AdminState)
 	assert.Equal(t, dtos.ToAutoEventModels(testAutoEvents), provisionWatcher.AutoEvents)
+	assert.Equal(t, testProtocolName, provisionWatcher.ProtocolName)
 }

--- a/models/provisionwatcher.go
+++ b/models/provisionwatcher.go
@@ -19,4 +19,5 @@ type ProvisionWatcher struct {
 	ServiceName         string
 	AdminState          AdminState
 	AutoEvents          []AutoEvent
+	ProtocolName        string
 }


### PR DESCRIPTION
Add ProtocolName to ProvisionWatcher for auto-discovered devices.

Signed-off-by: bruce <weichou1229@gmail.com>
