### PR TITLE
PS-373 Add new methods for NotificationClient

### DIFF
--- a/clients/http/notification.go
+++ b/clients/http/notification.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http/utils"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
@@ -61,11 +62,12 @@ func (client *NotificationClient) DeleteNotificationById(ctx context.Context, id
 }
 
 // NotificationsByCategory queries notifications with category, offset and limit
-func (client *NotificationClient) NotificationsByCategory(ctx context.Context, category string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
+func (client *NotificationClient) NotificationsByCategory(ctx context.Context, category string, offset int, limit int, ack string) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
 	requestPath := path.Join(common.ApiNotificationRoute, common.Category, category)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
+	requestParams.Set(common.Ack, ack)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -74,11 +76,12 @@ func (client *NotificationClient) NotificationsByCategory(ctx context.Context, c
 }
 
 // NotificationsByLabel queries notifications with label, offset and limit
-func (client *NotificationClient) NotificationsByLabel(ctx context.Context, label string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
+func (client *NotificationClient) NotificationsByLabel(ctx context.Context, label string, offset int, limit int, ack string) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
 	requestPath := path.Join(common.ApiNotificationRoute, common.Label, label)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
+	requestParams.Set(common.Ack, ack)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -87,11 +90,12 @@ func (client *NotificationClient) NotificationsByLabel(ctx context.Context, labe
 }
 
 // NotificationsByStatus queries notifications with status, offset and limit
-func (client *NotificationClient) NotificationsByStatus(ctx context.Context, status string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
+func (client *NotificationClient) NotificationsByStatus(ctx context.Context, status string, offset int, limit int, ack string) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
 	requestPath := path.Join(common.ApiNotificationRoute, common.Status, status)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
+	requestParams.Set(common.Ack, ack)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -100,11 +104,12 @@ func (client *NotificationClient) NotificationsByStatus(ctx context.Context, sta
 }
 
 // NotificationsByTimeRange query notifications with time range, offset and limit
-func (client *NotificationClient) NotificationsByTimeRange(ctx context.Context, start int, end int, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
+func (client *NotificationClient) NotificationsByTimeRange(ctx context.Context, start int, end int, offset int, limit int, ack string) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
 	requestPath := path.Join(common.ApiNotificationRoute, common.Start, strconv.Itoa(start), common.End, strconv.Itoa(end))
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
+	requestParams.Set(common.Ack, ack)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -113,11 +118,12 @@ func (client *NotificationClient) NotificationsByTimeRange(ctx context.Context, 
 }
 
 // NotificationsBySubscriptionName query notifications with subscriptionName, offset and limit
-func (client *NotificationClient) NotificationsBySubscriptionName(ctx context.Context, subscriptionName string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
+func (client *NotificationClient) NotificationsBySubscriptionName(ctx context.Context, subscriptionName string, offset int, limit int, ack string) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
 	requestPath := path.Join(common.ApiNotificationRoute, common.Subscription, common.Name, subscriptionName)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
+	requestParams.Set(common.Ack, ack)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -151,6 +157,43 @@ func (client *NotificationClient) CleanupNotifications(ctx context.Context) (res
 func (client *NotificationClient) DeleteProcessedNotificationsByAge(ctx context.Context, age int) (res dtoCommon.BaseResponse, err errors.EdgeX) {
 	path := path.Join(common.ApiNotificationRoute, common.Age, strconv.Itoa(age))
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// NotificationsByQueryConditions queries notifications with offset, limit, acknowledgement status, category and time range
+func (client *NotificationClient) NotificationsByQueryConditions(ctx context.Context, offset, limit int, ack string, conditionReq requests.GetNotificationRequest) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
+	requestParams := url.Values{}
+	requestParams.Set(common.Offset, strconv.Itoa(offset))
+	requestParams.Set(common.Limit, strconv.Itoa(limit))
+	requestParams.Set(common.Ack, ack)
+	err = utils.GetRequestWithBodyRawData(ctx, &res, client.baseUrl, common.ApiNotificationRoute, requestParams, conditionReq)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// DeleteNotificationByIds deletes notifications by ids
+func (client *NotificationClient) DeleteNotificationByIds(ctx context.Context, ids []string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
+	path := path.Join(common.ApiNotificationRoute, common.Ids, strings.Join(ids, common.CommaSeparator))
+	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// UpdateNotificationAckStatusByIds updates existing notification's acknowledgement status
+func (client *NotificationClient) UpdateNotificationAckStatusByIds(ctx context.Context, ack bool, ids []string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
+	pathAck := common.Unacknowledge
+	if ack {
+		pathAck = common.Acknowledge
+	}
+	path := path.Join(common.ApiNotificationRoute, pathAck, common.Ids, strings.Join(ids, common.CommaSeparator))
+	err = utils.PutRequest(ctx, &res, client.baseUrl, path, nil, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/http/notification_test.go
+++ b/clients/http/notification_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
@@ -60,7 +61,7 @@ func TestNotificationClient_NotificationsByCategory(t *testing.T) {
 	ts := newTestServer(http.MethodGet, urlPath, responses.MultiNotificationsResponse{})
 	defer ts.Close()
 	client := NewNotificationClient(ts.URL)
-	res, err := client.NotificationsByCategory(context.Background(), category, 0, 10)
+	res, err := client.NotificationsByCategory(context.Background(), category, 0, 10, "")
 	require.NoError(t, err)
 	require.IsType(t, responses.MultiNotificationsResponse{}, res)
 }
@@ -71,7 +72,7 @@ func TestNotificationClient_NotificationsByLabel(t *testing.T) {
 	ts := newTestServer(http.MethodGet, urlPath, responses.MultiNotificationsResponse{})
 	defer ts.Close()
 	client := NewNotificationClient(ts.URL)
-	res, err := client.NotificationsByLabel(context.Background(), label, 0, 10)
+	res, err := client.NotificationsByLabel(context.Background(), label, 0, 10, "")
 	require.NoError(t, err)
 	require.IsType(t, responses.MultiNotificationsResponse{}, res)
 }
@@ -82,7 +83,7 @@ func TestNotificationClient_NotificationsByStatus(t *testing.T) {
 	ts := newTestServer(http.MethodGet, urlPath, responses.MultiNotificationsResponse{})
 	defer ts.Close()
 	client := NewNotificationClient(ts.URL)
-	res, err := client.NotificationsByStatus(context.Background(), status, 0, 10)
+	res, err := client.NotificationsByStatus(context.Background(), status, 0, 10, "")
 	require.NoError(t, err)
 	require.IsType(t, responses.MultiNotificationsResponse{}, res)
 }
@@ -93,7 +94,7 @@ func TestNotificationClient_NotificationsBySubscriptionName(t *testing.T) {
 	ts := newTestServer(http.MethodGet, urlPath, responses.MultiNotificationsResponse{})
 	defer ts.Close()
 	client := NewNotificationClient(ts.URL)
-	res, err := client.NotificationsBySubscriptionName(context.Background(), subscriptionName, 0, 10)
+	res, err := client.NotificationsBySubscriptionName(context.Background(), subscriptionName, 0, 10, "")
 	require.NoError(t, err)
 	require.IsType(t, responses.MultiNotificationsResponse{}, res)
 }
@@ -105,7 +106,7 @@ func TestNotificationClient_NotificationsByTimeRange(t *testing.T) {
 	ts := newTestServer(http.MethodGet, urlPath, responses.MultiNotificationsResponse{})
 	defer ts.Close()
 	client := NewNotificationClient(ts.URL)
-	res, err := client.NotificationsByTimeRange(context.Background(), start, end, 0, 10)
+	res, err := client.NotificationsByTimeRange(context.Background(), start, end, 0, 10, "")
 	require.NoError(t, err)
 	require.IsType(t, responses.MultiNotificationsResponse{}, res)
 }
@@ -148,6 +149,37 @@ func TestNotificationClient_DeleteProcessedNotificationsByAge(t *testing.T) {
 	defer ts.Close()
 	client := NewNotificationClient(ts.URL)
 	res, err := client.DeleteProcessedNotificationsByAge(context.Background(), age)
+	require.NoError(t, err)
+	require.IsType(t, dtoCommon.BaseResponse{}, res)
+}
+
+func TestNotificationClient_NotificationsByQueryConditions(t *testing.T) {
+	ts := newTestServer(http.MethodGet, common.ApiNotificationRoute, responses.MultiNotificationsResponse{})
+	defer ts.Close()
+	client := NewNotificationClient(ts.URL)
+	res, err := client.NotificationsByQueryConditions(context.Background(), 0, 10, "", requests.GetNotificationRequest{})
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiNotificationsResponse{}, res)
+}
+
+func TestNotificationClient_DeleteNotificationByIds(t *testing.T) {
+	ids := []string{ExampleUUID}
+	path := path.Join(common.ApiNotificationRoute, common.Ids, strings.Join(ids, common.CommaSeparator))
+	ts := newTestServer(http.MethodDelete, path, dtoCommon.BaseResponse{})
+	defer ts.Close()
+	client := NewNotificationClient(ts.URL)
+	res, err := client.DeleteNotificationByIds(context.Background(), ids)
+	require.NoError(t, err)
+	require.IsType(t, dtoCommon.BaseResponse{}, res)
+}
+
+func TestNotificationClient_UpdateNotificationAckStatusByIds(t *testing.T) {
+	ids := []string{ExampleUUID}
+	path := path.Join(common.ApiNotificationRoute, common.Acknowledge, common.Ids, strings.Join(ids, common.CommaSeparator))
+	ts := newTestServer(http.MethodPut, path, dtoCommon.BaseResponse{})
+	defer ts.Close()
+	client := NewNotificationClient(ts.URL)
+	res, err := client.UpdateNotificationAckStatusByIds(context.Background(), true, ids)
 	require.NoError(t, err)
 	require.IsType(t, dtoCommon.BaseResponse{}, res)
 }

--- a/clients/interfaces/notification.go
+++ b/clients/interfaces/notification.go
@@ -22,16 +22,16 @@ type NotificationClient interface {
 	NotificationById(ctx context.Context, id string) (responses.NotificationResponse, errors.EdgeX)
 	// DeleteNotificationById deletes a notification by id.
 	DeleteNotificationById(ctx context.Context, id string) (common.BaseResponse, errors.EdgeX)
-	// NotificationsByCategory queries notifications with category, offset and limit
-	NotificationsByCategory(ctx context.Context, category string, offset int, limit int) (responses.MultiNotificationsResponse, errors.EdgeX)
-	// NotificationsByLabel queries notifications with label, offset and limit
-	NotificationsByLabel(ctx context.Context, label string, offset int, limit int) (responses.MultiNotificationsResponse, errors.EdgeX)
-	// NotificationsByStatus queries notifications with status, offset and limit
-	NotificationsByStatus(ctx context.Context, status string, offset int, limit int) (responses.MultiNotificationsResponse, errors.EdgeX)
-	// NotificationsByTimeRange query notifications with time range, offset and limit
-	NotificationsByTimeRange(ctx context.Context, start int, end int, offset int, limit int) (responses.MultiNotificationsResponse, errors.EdgeX)
-	// NotificationsBySubscriptionName query notifications with subscriptionName, offset and limit
-	NotificationsBySubscriptionName(ctx context.Context, subscriptionName string, offset int, limit int) (responses.MultiNotificationsResponse, errors.EdgeX)
+	// NotificationsByCategory queries notifications with category, offset, ack and limit
+	NotificationsByCategory(ctx context.Context, category string, offset int, limit int, ack string) (responses.MultiNotificationsResponse, errors.EdgeX)
+	// NotificationsByLabel queries notifications with label, offset, ack and limit
+	NotificationsByLabel(ctx context.Context, label string, offset int, limit int, ack string) (responses.MultiNotificationsResponse, errors.EdgeX)
+	// NotificationsByStatus queries notifications with status, offset, ack and limit
+	NotificationsByStatus(ctx context.Context, status string, offset int, limit int, ack string) (responses.MultiNotificationsResponse, errors.EdgeX)
+	// NotificationsByTimeRange query notifications with time range, offset, ack and limit
+	NotificationsByTimeRange(ctx context.Context, start int, end int, offset int, limit int, ack string) (responses.MultiNotificationsResponse, errors.EdgeX)
+	// NotificationsBySubscriptionName query notifications with subscriptionName, offset, ack and limit
+	NotificationsBySubscriptionName(ctx context.Context, subscriptionName string, offset int, limit int, ack string) (responses.MultiNotificationsResponse, errors.EdgeX)
 	// CleanupNotificationsByAge removes notifications that are older than age. And the corresponding transmissions will also be deleted.
 	// Age is supposed in milliseconds since modified timestamp
 	CleanupNotificationsByAge(ctx context.Context, age int) (common.BaseResponse, errors.EdgeX)
@@ -41,4 +41,10 @@ type NotificationClient interface {
 	// Age is supposed in milliseconds since modified timestamp
 	// Please notice that this API is only for processed notifications (status = PROCESSED). If the deletion purpose includes each kind of notifications, please refer to cleanup API.
 	DeleteProcessedNotificationsByAge(ctx context.Context, age int) (common.BaseResponse, errors.EdgeX)
+	// NotificationsByQueryConditions queries notifications with offset, limit, acknowledgement status, category and time range
+	NotificationsByQueryConditions(ctx context.Context, offset, limit int, ack string, conditionReq requests.GetNotificationRequest) (responses.MultiNotificationsResponse, errors.EdgeX)
+	// DeleteNotificationByIds deletes notifications by ids
+	DeleteNotificationByIds(ctx context.Context, ids []string) (common.BaseResponse, errors.EdgeX)
+	// UpdateNotificationAckStatusByIds updates existing notification's acknowledgement status
+	UpdateNotificationAckStatusByIds(ctx context.Context, ack bool, ids []string) (common.BaseResponse, errors.EdgeX)
 }

--- a/common/constants.go
+++ b/common/constants.go
@@ -183,6 +183,7 @@ const (
 	User          = "user"
 	Group         = "group"
 	PublicKey     = "rsa_public_key"
+	Ack           = "ack"
 	Acknowledge   = "acknowledge"
 	Unacknowledge = "unacknowledge"
 


### PR DESCRIPTION
Added methods:
- NotificationsByQueryConditions
- DeleteNotificationByIds
- UpdateNotificationAckStatusByIds

Also added parameter `ack` to the following methods:
- NotificationsByCategory
- NotificationsByLabel
- NotificationsByStatus
- NotificationsByTimeRange
- NotificationsBySubscriptionName

For further information on the Notification Service API changes, refer to: https://github.com/IOTechSystems/edgex-go-private/commit/3ba5e37ab791cde84693040f650503db57d718df

Signed-off-by: Felix Ting <felix@iotechsys.com>
