### PR TITLE
EDX-2984 Move DeviceChangedNotification dto from edgex-go to go-mod-core-contracts

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -289,6 +289,7 @@ const (
 	SupportProvisionServiceKey          = "support-provision"
 	SystemManagementAgentServiceKey     = "sys-mgmt-agent"
 	SupportSchedulerServiceKey          = "support-scheduler"
+	SupportSparkplugServiceKey          = "support-sparkplug"
 	SecuritySecretStoreSetupServiceKey  = "security-secretstore-setup"
 	SecurityProxySetupServiceKey        = "security-proxy-setup"
 	SecurityFileTokenProviderServiceKey = "security-file-token-provider"
@@ -312,4 +313,13 @@ const (
 // Constants for Notification Category
 const (
 	DisconnectAlert = "Disconnection"
+)
+
+// Constants for DeviceChangedNotification
+const (
+	DeviceCreateAction = "Device creation"
+	DeviceUpdateAction = "Device update"
+	DeviceRemoveAction = "Device removal"
+
+	DeviceChangedNotificationCategory = "DEVICE_CHANGED"
 )

--- a/dtos/address.go
+++ b/dtos/address.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -87,7 +87,7 @@ type MQTTPubAddress struct {
 	ConnectTimeout int    `json:"connectTimeout,omitempty"`
 }
 
-func NewMQTTAddress(host string, port int, publisher string, topic string) Address {
+func NewMQTTAddress(host string, port int, publisher string, topic string, authMode string, secretPath string, skipCertVerify bool) Address {
 	return Address{
 		Type: common.MQTT,
 		Host: host,
@@ -96,6 +96,11 @@ func NewMQTTAddress(host string, port int, publisher string, topic string) Addre
 			Publisher: publisher,
 		},
 		MessageBus: MessageBus{Topic: topic},
+		Security: Security{
+			AuthMode:       authMode,
+			SecretPath:     secretPath,
+			SkipCertVerify: skipCertVerify,
+		},
 	}
 }
 

--- a/dtos/devicechangednotification.go
+++ b/dtos/devicechangednotification.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 IOTech Ltd
+
+package dtos
+
+import (
+	"encoding/json"
+)
+
+type DeviceNotificationContent struct {
+	DeviceName        string `json:"deviceName"`
+	DeviceServiceName string `json:"deviceServiceName"`
+	ActionType        string `json:"actionType"`
+	OperatingState    string `json:"operatingState"`
+	AdminState        string `json:"adminState"`
+}
+
+func NewDeviceNotificationContent(device Device, action string) DeviceNotificationContent {
+	return DeviceNotificationContent{
+		DeviceName:        device.Name,
+		DeviceServiceName: device.ServiceName,
+		ActionType:        action,
+		OperatingState:    device.OperatingState,
+		AdminState:        device.AdminState,
+	}
+}
+
+func (d DeviceNotificationContent) String() (string, error) {
+	if b, err := json.Marshal(d); err == nil {
+		return string(b), nil
+	} else {
+		return "", err
+	}
+}


### PR DESCRIPTION
As DeviceChangedNotification DTO is required by new support-sparkplug service, move and expose the DTO definition from edgex-go-private to go-mod-core-contracts.

Signed-off-by: Jude Hung <jude@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->