### PR TITLE
EDX-3040 Add scheme as part of NewMQTTAddressWithSecurity signature

### DIFF
--- a/dtos/address.go
+++ b/dtos/address.go
@@ -99,11 +99,12 @@ func NewMQTTAddress(host string, port int, publisher string, topic string) Addre
 	}
 }
 
-func NewMQTTAddressWithSecurity(host string, port int, publisher string, topic string, authMode string, secretPath string, skipCertVerify bool) Address {
+func NewMQTTAddressWithSecurity(scheme string, host string, port int, publisher string, topic string, authMode string, secretPath string, skipCertVerify bool) Address {
 	return Address{
-		Type: common.MQTT,
-		Host: host,
-		Port: port,
+		Type:   common.MQTT,
+		Scheme: scheme,
+		Host:   host,
+		Port:   port,
 		MQTTPubAddress: MQTTPubAddress{
 			Publisher: publisher,
 		},


### PR DESCRIPTION
When mqtt-broker is enabled with TLS connection, scheme needs to be
"tcps" instead of default "tcp".  Add scheme as part of
NewMQTTAddressWithSecurity signature, so that a MQTT Address can be
specified with scheme during creation.

Signed-off-by: Jude Hung <jude@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->