### PR TITLE
EDX-3024 Add // +build comment for go 1.16 for DCT

### DIFF
--- a/common/dummy_validator.go
+++ b/common/dummy_validator.go
@@ -1,4 +1,5 @@
 //go:build no_dto_validator
+// +build no_dto_validator
 
 //
 // Copyright (C) 2022 IOTech Ltd

--- a/common/validator.go
+++ b/common/validator.go
@@ -1,4 +1,5 @@
 //go:build !no_dto_validator
+// +build !no_dto_validator
 
 //
 // Copyright (C) 2020-2021 IOTech Ltd


### PR DESCRIPTION
DCT still uses go 1.16, so it needs `// +build` comment(`//go:build` comment for go 1.17+)

Signed-off-by: Ginny Guan <ginny@iotechsys.com>
