### PR TITLE
EDX-3111 Allow dot and asterisk char in the name field

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -39,7 +39,7 @@ const (
 	rFC3986UnreservedCharsRegexString = "^[a-zA-Z0-9-_~:;=]+$"
 	intervalDatetimeLayout            = "20060102T150405"
 	name                              = "Name"
-	reservedCharsRegexString          = "^[^/#.*+$]+$"
+	reservedCharsRegexString          = "^[^/#+$]+$"
 )
 
 var (
@@ -102,7 +102,7 @@ func getErrorMessage(e validator.FieldError) string {
 	case dtoRFC3986UnreservedCharTag:
 		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~:;=", fieldName)
 	case dtoNoReservedCharTag:
-		msg = fmt.Sprintf("%s field does not allow reserved characters which are /#.*+$", fieldName)
+		msg = fmt.Sprintf("%s field does not allow reserved characters which are /#+$", fieldName)
 	default:
 		msg = fmt.Sprintf("%s field validation failed on the %s tag", fieldName, tag)
 	}

--- a/dtos/requests/const_test.go
+++ b/dtos/requests/const_test.go
@@ -81,8 +81,6 @@ var namesWithReservedChar = []string{
 var namesWithReservedCharEdgeX = []string{
 	"name/001",
 	"name#001",
-	"name.001",
-	"name*001",
 	"name+001",
 	"name$001",
 }


### PR DESCRIPTION
Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->