### PR TITLE
EDX-3131 Handle Client API error response

### DIFF
--- a/clients/http/utils/common.go
+++ b/clients/http/utils/common.go
@@ -224,7 +224,7 @@ func sendRequest(ctx context.Context, req *http.Request) ([]byte, errors.EdgeX) 
 	var errResponse commonDTO.BaseResponse
 	e := json.Unmarshal(bodyBytes, &errResponse)
 	if e != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to json decoding error response", e)
+		return nil, errors.NewCommonEdgeX(errors.KindMapping(resp.StatusCode), string(bodyBytes), e)
 	}
 
 	return nil, errors.NewCommonEdgeX(errors.KindMapping(errResponse.StatusCode), errResponse.Message, nil)

--- a/clients/http/utils/request.go
+++ b/clients/http/utils/request.go
@@ -63,7 +63,7 @@ func GetRequestAndReturnBinaryRes(ctx context.Context, baseUrl string, requestPa
 	var errResponse commonDTO.BaseResponse
 	e := json.Unmarshal(bodyBytes, &errResponse)
 	if e != nil {
-		return nil, "", errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to json decoding error response", e)
+		return nil, "", errors.NewCommonEdgeX(errors.KindMapping(resp.StatusCode), string(bodyBytes), e)
 	}
 
 	return nil, "", errors.NewCommonEdgeX(errors.KindMapping(errResponse.StatusCode), errResponse.Message, nil)


### PR DESCRIPTION
If failed to json unmarshal, return the response error instead of the json format error.
