### PR TITLE
EDX-3281 Allow using empty string to update ProvisionWatcher

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -31,6 +31,9 @@ const (
 	dtoRFC3986UnreservedCharTag = "edgex-dto-rfc3986-unreserved-chars"
 	dtoInterDatetimeTag         = "edgex-dto-interval-datetime"
 	dtoNoReservedCharTag        = "edgex-dto-no-reserved-chars"
+
+	emptyOrDtoRFC3986UnreservedCharTag = "len=0|" + dtoRFC3986UnreservedCharTag
+	emptyOrDtoNoReservedCharTag        = "len=0|" + dtoNoReservedCharTag
 )
 
 const (
@@ -99,9 +102,9 @@ func getErrorMessage(e validator.FieldError) string {
 		msg = fmt.Sprintf("%s field needs a uuid", fieldName)
 	case dtoNoneEmptyStringTag:
 		msg = fmt.Sprintf("%s field should not be empty string", fieldName)
-	case dtoRFC3986UnreservedCharTag:
+	case dtoRFC3986UnreservedCharTag, emptyOrDtoRFC3986UnreservedCharTag:
 		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~:;=", fieldName)
-	case dtoNoReservedCharTag:
+	case dtoNoReservedCharTag, emptyOrDtoNoReservedCharTag:
 		msg = fmt.Sprintf("%s field does not allow reserved characters which are /#+$", fieldName)
 	default:
 		msg = fmt.Sprintf("%s field validation failed on the %s tag", fieldName, tag)

--- a/dtos/provisionwatcher.go
+++ b/dtos/provisionwatcher.go
@@ -42,16 +42,16 @@ type UpdateProvisionWatcher struct {
 	Identifiers         map[string]string   `json:"identifiers" validate:"omitempty,gt=0,dive,keys,required,endkeys,required"`
 	BlockingIdentifiers map[string][]string `json:"blockingIdentifiers"`
 
-	DeviceNameTemplate *string     `json:"deviceNameTemplate" validate:"omitempty,edgex-dto-no-reserved-chars"`
-	ProfileName        *string     `json:"profileName" validate:"omitempty,edgex-dto-no-reserved-chars"`
+	DeviceNameTemplate *string     `json:"deviceNameTemplate" validate:"omitempty,len=0|edgex-dto-no-reserved-chars"`
+	ProfileName        *string     `json:"profileName" validate:"omitempty,len=0|edgex-dto-no-reserved-chars"`
 	ServiceName        *string     `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState         *string     `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents         []AutoEvent `json:"autoEvents" validate:"dive"`
-	ProtocolName       *string     `json:"protocolName" validate:"omitempty,edgex-dto-rfc3986-unreserved-chars"`
+	ProtocolName       *string     `json:"protocolName" validate:"omitempty,len=0|edgex-dto-rfc3986-unreserved-chars"`
 	DeviceDescription  *string     `json:"deviceDescription"`
 	DeviceLabels       []string    `json:"deviceLabels"`
 
-	ProfileNameTemplate *string  `json:"profileNameTemplate" validate:"omitempty,edgex-dto-no-reserved-chars"`
+	ProfileNameTemplate *string  `json:"profileNameTemplate" validate:"omitempty,len=0|edgex-dto-no-reserved-chars"`
 	ProfileLabels       []string `json:"profileLabels"`
 	ProfileDescription  *string  `json:"profileDescription"`
 }


### PR DESCRIPTION
When using the String pointer in the DTO, the validation tag omits the nil value and checks empty String with reserved chars. To preventing checking error, add len=0 to allow empty string for updating the profileName, deviceNameTemplate, profileNameTemplate, protocolName.

Signed-off-by: bruce <weichou1229@gmail.com>