### PR TITLE
EDX-3379 Allow the null reading value

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -98,6 +98,9 @@ func NewObjectReading(profileName string, deviceName string, resourceName string
 }
 
 func convertInterfaceValue(valueType string, value interface{}) (string, error) {
+	if value == nil {
+		return "", nil
+	}
 	switch valueType {
 	case common.ValueTypeBool:
 		return convertSimpleValue(valueType, reflect.Bool, value)


### PR DESCRIPTION
Since the XRT might return a null value if the resource is unreadable, xrt-bridge needs to handle the null value.
