### PR TITLE
EDX-3537 Implement the KVS http client for Keeper

### DIFF
--- a/clients/http/kvs.go
+++ b/clients/http/kvs.go
@@ -1,0 +1,88 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package http
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http/utils"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+)
+
+// KVSClient is the REST client for invoking the key-value APIs(/kvs/*) from Core Keeper
+type KVSClient struct {
+	baseUrl string
+}
+
+// NewKVSClient creates an instance of KVSClient
+func NewKVSClient(baseUrl string) interfaces.KVSClient {
+	return &KVSClient{
+		baseUrl: baseUrl,
+	}
+}
+
+// UpdateValuesByKey updates values of the specified key and the child keys defined in the request payload.
+// If no key exists at the given path, the key(s) will be created.
+func (kc KVSClient) UpdateValuesByKey(ctx context.Context, key string, req requests.UpdateKeysRequest) (res responses.KeysResponse, err errors.EdgeX) {
+	path := utils.EscapeAndJoinPath(common.ApiKVSRoute, common.Key, key)
+	queryParams := url.Values{}
+	queryParams.Set(common.Flatten, common.ValueTrue)
+	err = utils.PutRequest(ctx, &res, kc.baseUrl, path, queryParams, req)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// ValuesByKey returns the values of the specified key prefix.
+func (kc KVSClient) ValuesByKey(ctx context.Context, key string) (res responses.MultiKeyValueResponse, err errors.EdgeX) {
+	path := utils.EscapeAndJoinPath(common.ApiKVSRoute, common.Key, key)
+	queryParams := url.Values{}
+	queryParams.Set(common.Plaintext, common.ValueTrue)
+	err = utils.GetRequest(ctx, &res, kc.baseUrl, path, queryParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// ListKeys returns the list of the keys with the specified key prefix.
+func (kc KVSClient) ListKeys(ctx context.Context, key string) (res responses.KeysResponse, err errors.EdgeX) {
+	path := utils.EscapeAndJoinPath(common.ApiKVSRoute, common.Key, key)
+	queryParams := url.Values{}
+	queryParams.Set(common.KeyOnly, common.ValueTrue)
+	err = utils.GetRequest(ctx, &res, kc.baseUrl, path, queryParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// DeleteKey deletes the specified key.
+func (kc KVSClient) DeleteKey(ctx context.Context, key string) (res responses.KeysResponse, err errors.EdgeX) {
+	path := utils.EscapeAndJoinPath(common.ApiKVSRoute, common.Key, key)
+	err = utils.DeleteRequest(ctx, &res, kc.baseUrl, path)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// DeleteKeysByPrefix deletes all keys with the specified prefix.
+func (kc KVSClient) DeleteKeysByPrefix(ctx context.Context, key string) (res responses.KeysResponse, err errors.EdgeX) {
+	path := utils.EscapeAndJoinPath(common.ApiKVSRoute, common.Key, key)
+	queryParams := url.Values{}
+	queryParams.Set("prefixMatch", common.ValueTrue)
+	err = utils.DeleteRequestWithParams(ctx, &res, kc.baseUrl, path, queryParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}

--- a/clients/http/kvs_test.go
+++ b/clients/http/kvs_test.go
@@ -1,0 +1,74 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+
+	"github.com/stretchr/testify/require"
+)
+
+const TestKey = "TestWritable"
+
+func TestUpdateValuesByKey(t *testing.T) {
+	ts := newTestServer(http.MethodPut, common.ApiKVSRoute+"/"+common.Key+"/"+TestKey, responses.KeysResponse{})
+	defer ts.Close()
+
+	client := NewKVSClient(ts.URL)
+	res, err := client.UpdateValuesByKey(context.Background(), TestKey, requests.UpdateKeysRequest{})
+
+	require.NoError(t, err)
+	require.IsType(t, responses.KeysResponse{}, res)
+}
+
+func TestValuesByKey(t *testing.T) {
+	ts := newTestServer(http.MethodGet, common.ApiKVSRoute+"/"+common.Key+"/"+TestKey, responses.MultiKeyValueResponse{})
+	defer ts.Close()
+
+	client := NewKVSClient(ts.URL)
+	res, err := client.ValuesByKey(context.Background(), TestKey)
+
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiKeyValueResponse{}, res)
+}
+
+func TestListKeys(t *testing.T) {
+	ts := newTestServer(http.MethodGet, common.ApiKVSRoute+"/"+common.Key+"/"+TestKey, responses.KeysResponse{})
+	defer ts.Close()
+
+	client := NewKVSClient(ts.URL)
+	res, err := client.ListKeys(context.Background(), TestKey)
+
+	require.NoError(t, err)
+	require.IsType(t, responses.KeysResponse{}, res)
+}
+
+func TestDeleteKeys(t *testing.T) {
+	ts := newTestServer(http.MethodDelete, common.ApiKVSRoute+"/"+common.Key+"/"+TestKey, responses.KeysResponse{})
+	defer ts.Close()
+
+	client := NewKVSClient(ts.URL)
+	res, err := client.DeleteKey(context.Background(), TestKey)
+
+	require.NoError(t, err)
+	require.IsType(t, responses.KeysResponse{}, res)
+}
+
+func TestDeleteKeysByPrefix(t *testing.T) {
+	ts := newTestServer(http.MethodDelete, common.ApiKVSRoute+"/"+common.Key+"/"+TestKey, responses.KeysResponse{})
+	defer ts.Close()
+
+	client := NewKVSClient(ts.URL)
+	res, err := client.DeleteKeysByPrefix(context.Background(), TestKey)
+
+	require.NoError(t, err)
+	require.IsType(t, responses.KeysResponse{}, res)
+}

--- a/clients/http/utils/request.go
+++ b/clients/http/utils/request.go
@@ -238,3 +238,20 @@ func DeleteRequest(ctx context.Context, returnValuePointer interface{}, baseUrl 
 	}
 	return nil
 }
+
+// DeleteRequestWithParams makes the delete request with URL query params and return the body
+func DeleteRequestWithParams(ctx context.Context, returnValuePointer interface{}, baseUrl string, requestPath string, requestParams url.Values) errors.EdgeX {
+	req, err := createRequest(ctx, http.MethodDelete, baseUrl, requestPath, requestParams)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	res, err := sendRequest(ctx, req)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if err := json.Unmarshal(res, returnValuePointer); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
+	}
+	return nil
+}

--- a/clients/interfaces/kvs.go
+++ b/clients/interfaces/kvs.go
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+)
+
+// KVSClient defines the interface for interactions with the kvs endpoint on the Edge Xpert core-keeper service.
+type KVSClient interface {
+	// UpdateValuesByKey updates values of the specified key and the child keys defined in the request payload.
+	// If no key exists at the given path, the key(s) will be created.
+	UpdateValuesByKey(ctx context.Context, key string, reqs requests.UpdateKeysRequest) (responses.KeysResponse, errors.EdgeX)
+	// ValuesByKey returns the values of the specified key prefix.
+	ValuesByKey(ctx context.Context, key string) (responses.MultiKeyValueResponse, errors.EdgeX)
+	// ListKeys returns the list of the keys with the specified key prefix.
+	ListKeys(ctx context.Context, key string) (responses.KeysResponse, errors.EdgeX)
+	// DeleteKey deletes the specified key.
+	DeleteKey(ctx context.Context, key string) (responses.KeysResponse, errors.EdgeX)
+	// DeleteKeysByPrefix deletes all keys with the specified prefix.
+	DeleteKeysByPrefix(ctx context.Context, key string) (responses.KeysResponse, errors.EdgeX)
+}

--- a/common/constants.go
+++ b/common/constants.go
@@ -137,6 +137,9 @@ const (
 	ApiRuleRoute       = ApiBase + "/rule"
 	ApiAllRulesRoute   = ApiRuleRoute + "/" + All
 	ApiRuleByNameRoute = ApiRuleRoute + "/" + Name + "/{" + Name + "}"
+
+	ApiKVSRoute      = ApiBase + "/kvs"
+	ApiKVSByKeyRoute = ApiKVSRoute + "/" + Key + "/{" + Key + "}"
 )
 
 // Constants related to defined url path names and parameters in the v2 service APIs
@@ -191,12 +194,16 @@ const (
 	Ack           = "ack"
 	Acknowledge   = "acknowledge"
 	Unacknowledge = "unacknowledge"
+	Key           = "key"
 
 	Offset      = "offset"         //query string to specify the number of items to skip before starting to collect the result set.
 	Limit       = "limit"          //query string to specify the numbers of items to return
 	Labels      = "labels"         //query string to specify associated user-defined labels for querying a given object. More than one label may be specified via a comma-delimited list
 	PushEvent   = "ds-pushevent"   //query string to specify if an event should be pushed to the EdgeX system
 	ReturnEvent = "ds-returnevent" //query string to specify if an event should be returned from device service
+	Flatten     = "flatten"        //query string to specify if the request json payload should be flattened to update multiple keys with the same prefix
+	KeyOnly     = "keyOnly"        //query string to specify if the response will only return the keys of the specified query key prefix, without values and metadata
+	Plaintext   = "plaintext"      //query string to specify if the response will return the stored plain text value of the key(s) without any encoding
 )
 
 // Constants related to the default value of query strings in the v2 service APIs
@@ -290,6 +297,7 @@ const (
 	CoreCommandServiceKey               = "core-command"
 	CoreDataServiceKey                  = "core-data"
 	CoreMetaDataServiceKey              = "core-metadata"
+	CoreKeeperServiceKey                = "core-keeper"
 	SupportLoggingServiceKey            = "support-logging"
 	SupportNotificationsServiceKey      = "support-notifications"
 	SupportProvisionServiceKey          = "support-provision"

--- a/dtos/requests/kvs.go
+++ b/dtos/requests/kvs.go
@@ -1,0 +1,65 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package requests
+
+import (
+	"encoding/json"
+
+	dtoCommon "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+)
+
+// UpdateKeysRequest defines the Request Content for PUT Key DTO.
+type UpdateKeysRequest struct {
+	dtoCommon.BaseRequest `json:",inline"`
+	Value                 any `json:"value,omitempty"`
+}
+
+// Validate checks if the fields are valid of the UpdateKeysRequest struct
+func (u UpdateKeysRequest) Validate() errors.EdgeX {
+	// check if Value field is nil
+	if u.Value == nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "the value field is undefined", nil)
+	}
+	// check if Value field is an empty map
+	if v, ok := u.Value.(map[string]any); ok {
+		if len(v) == 0 {
+			return errors.NewCommonEdgeX(errors.KindContractInvalid, "the value field is an empty object", nil)
+		}
+	} else {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "the value field is invalid", nil)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements the Unmarshaler interface for the UpdateKeysRequest type
+func (u *UpdateKeysRequest) UnmarshalJSON(b []byte) error {
+	alias := struct {
+		dtoCommon.BaseRequest
+		Value any
+	}{}
+
+	if err := json.Unmarshal(b, &alias); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal request body as JSON.", err)
+	}
+	*u = UpdateKeysRequest(alias)
+
+	if err := u.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateKeysReqToKVModels transforms the UpdateKeysRequest DTO to the KV model
+func UpdateKeysReqToKVModels(req UpdateKeysRequest, key string) models.KVS {
+	var kv models.KVS
+	kv.Value = req.Value
+	kv.Key = key
+
+	return kv
+}

--- a/dtos/requests/kvs_test.go
+++ b/dtos/requests/kvs_test.go
@@ -1,0 +1,103 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package requests
+
+import (
+	"encoding/json"
+	"testing"
+
+	dtoCommon "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testValueMap          = map[string]any{"aaa": "1", "bbb": "2"}
+	testUpdateKeysRequest = UpdateKeysRequest{
+		BaseRequest: dtoCommon.BaseRequest{
+			RequestId:   ExampleUUID,
+			Versionable: dtoCommon.NewVersionable(),
+		},
+		Value: testValueMap,
+	}
+)
+
+func TestUpdateKeysRequest_Validate(t *testing.T) {
+	valid := testUpdateKeysRequest
+	nilValue := testUpdateKeysRequest
+	nilValue.Value = nil
+	emptyValue := testUpdateKeysRequest
+	emptyValue.Value = map[string]string{}
+	emptyMap := testUpdateKeysRequest
+	emptyMap.Value = make(map[string]any)
+
+	tests := []struct {
+		name        string
+		request     UpdateKeysRequest
+		expectedErr bool
+	}{
+		{"valid UpdateKeysRequest", valid, false},
+		{"invalid UpdateKeysRequest, nil Value", nilValue, true},
+		{"invalid UpdateKeysRequest, invalid Value", emptyValue, true},
+		{"invalid UpdateKeysRequest, empty Value", emptyMap, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdateKeysRequest_UnmarshalJSON(t *testing.T) {
+	valid := testUpdateKeysRequest
+	resultTestBytes, _ := json.Marshal(testUpdateKeysRequest)
+	type args struct {
+		data []byte
+	}
+
+	tests := []struct {
+		name        string
+		request     UpdateKeysRequest
+		args        args
+		expectedErr bool
+	}{
+		{"unmarshal UpdateKeysRequest with success", valid, args{resultTestBytes}, false},
+		{"unmarshal invalid UpdateKeysRequest, empty data", UpdateKeysRequest{}, args{[]byte{}}, true},
+		{"unmarshal invalid UpdateKeysRequest, string data", UpdateKeysRequest{}, args{[]byte("Invalid UpdateKeysRequest")}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var expected = tt.request
+			err := tt.request.UnmarshalJSON(tt.args.data)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, expected, tt.request, "Unmarshal did not result in expected UpdateKeysRequest.")
+			}
+		})
+	}
+}
+
+func Test_UpdateKeysRequestToKVSModels(t *testing.T) {
+	testKey := "TestKey"
+	requests := testUpdateKeysRequest
+	expectedKVSModel := models.KVS{
+		Key: testKey,
+		StoredData: models.StoredData{
+			DBTimestamp: models.DBTimestamp{},
+			Value:       testValueMap,
+		},
+	}
+	resultModel := UpdateKeysReqToKVModels(requests, testKey)
+	assert.Equal(t, expectedKVSModel, resultModel, "UpdateKeysRequestToKVSModels did not result in expected KVS model.")
+}

--- a/dtos/responses/kvs.go
+++ b/dtos/responses/kvs.go
@@ -1,0 +1,44 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package responses
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+)
+
+// MultiKVResponse defines the Response Content for GET Keys of core-keeper (GET /kvs/key/{key} API).
+type MultiKVResponse struct {
+	common.BaseResponse `json:",inline"`
+	Response            []models.KVResponse `json:"response"`
+}
+
+// MultiKeyValueResponse defines the Response DTO for ValuesByKey HTTP client.
+// This DTO is obtained from GET /kvs/key/{key} API with keyOnly is false.
+type MultiKeyValueResponse struct {
+	common.BaseResponse `json:",inline"`
+	Response            []models.KVS `json:"response"`
+}
+
+func NewMultiKVResponse(requestId string, message string, statusCode int, resp []models.KVResponse) MultiKVResponse {
+	return MultiKVResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Response:     resp,
+	}
+}
+
+// KeysResponse defines the Response Content for DELETE Keys controller of core-keeper (DELETE /kvs/key/{key} API).
+// This DTO also defines the Response Content obtained from GET /kvs/key/{key} API with keyOnly is true.
+type KeysResponse struct {
+	common.BaseResponse `json:",inline"`
+	Response            []models.KeyOnly `json:"response"`
+}
+
+func NewKeysResponse(requestId string, message string, statusCode int, keys []models.KeyOnly) KeysResponse {
+	return KeysResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Response:     keys,
+	}
+}

--- a/dtos/responses/kvs_test.go
+++ b/dtos/responses/kvs_test.go
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package responses
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	expectedRequestId  = "123456"
+	expectedStatusCode = 200
+	expectedMessage    = "unit test message"
+	expectedTestKey    = "TestKey"
+)
+
+func TestNewMultiKVResponse(t *testing.T) {
+	expectedKV := models.KVS{
+		Key: expectedTestKey,
+		StoredData: models.StoredData{
+			DBTimestamp: models.DBTimestamp{},
+			Value:       "TestValue",
+		},
+	}
+	expectedResp := []models.KVResponse{&expectedKV}
+	actual := NewMultiKVResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedResp)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedResp, actual.Response)
+}
+
+func TestNewKeysResponse(t *testing.T) {
+	expectedResp := []models.KeyOnly{expectedTestKey}
+	actual := NewKeysResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedResp)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedResp, actual.Response)
+}

--- a/models/kvs.go
+++ b/models/kvs.go
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package models
+
+// KVResponse defines the Response Content for GET Keys of core-keeper (GET /kvs/key/{key} API).
+type KVResponse interface {
+	SetKey(string)
+}
+
+// KVS defines the Response Content for GET Keys controller with keyOnly is false which inherits KVResponse interface.
+type KVS struct {
+	Key string `json:"key,omitempty"`
+	StoredData
+}
+
+type StoredData struct {
+	DBTimestamp
+	Value interface{} `json:"value,omitempty"`
+}
+
+// KeyOnly defines the Response Content for GET Keys  with keyOnly is true which inherits KVResponse interface.
+type KeyOnly string
+
+func (kv *KVS) SetKey(newKey string) {
+	kv.Key = newKey
+}
+
+func (key *KeyOnly) SetKey(newKey string) {
+	*key = KeyOnly(newKey)
+}


### PR DESCRIPTION
Implement the KVS http client for Keeper which invokes the /kvs APIs.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->