### PR TITLE
EDX-3817 Use PathEscape to encode the API path

### DIFF
--- a/clients/http/utils/xpert.go
+++ b/clients/http/utils/xpert.go
@@ -20,7 +20,7 @@ func EscapeAndJoinPath(apiRoutePath string, pathVariables ...string) string {
 	elements := make([]string, len(pathVariables)+1)
 	elements[0] = apiRoutePath // we don't need to escape the route path like /device, /reading, ...,etc.
 	for i, e := range pathVariables {
-		elements[i+1] = url.QueryEscape(e)
+		elements[i+1] = url.PathEscape(e)
 	}
 	return path.Join(elements...)
 }


### PR DESCRIPTION
Use PathEscape to encode the API path because the url.QueryEscape encode the empty space to plus sign, and plus sign is invalid for publishing the MQTT message.