### PR TITLE
EDX-3997 Add min/max params for edgex-dto-duration tag

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -2,7 +2,7 @@
 // +build !no_dto_validator
 
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -97,7 +97,7 @@ func getErrorMessage(e validator.FieldError) string {
 	case "gt":
 		msg = fmt.Sprintf("%s field should greater than %s", fieldName, fieldValue)
 	case dtoDurationTag:
-		msg = fmt.Sprintf("%s field should follows the ISO 8601 Durations format. Eg,100ms, 24h", fieldName)
+		msg = fmt.Sprintf("%s field should follows the ISO 8601 Durations format, e.g.,100ms, 24h, or be greater than or equal to the minimum value %s ", fieldName, fieldValue)
 	case dtoUuidTag:
 		msg = fmt.Sprintf("%s field needs a uuid", fieldName)
 	case dtoNoneEmptyStringTag:
@@ -113,9 +113,42 @@ func getErrorMessage(e validator.FieldError) string {
 }
 
 // ValidateDuration validate field which should follow the ISO 8601 Durations format
+// the min/max of the Duration can be set via the tag params
+// ex. edgex-dto-duration=10ms0x2C24h - 10ms represents the minimum Duration and 24h represents the maximum Duration
+// 0x2c is the UTF-8 hex encoding of comma (,) as the min/max value separator
 func ValidateDuration(fl validator.FieldLevel) bool {
-	_, err := time.ParseDuration(fl.Field().String())
-	return err == nil
+	duration, err := time.ParseDuration(fl.Field().String())
+	if err != nil {
+		return false
+	}
+
+	// if min/max are defined from tag param, check if the duration value is in the duration range
+	param := fl.Param()
+	var min, max time.Duration
+	if param != "" {
+		params := strings.Split(param, CommaSeparator)
+		if len(params) > 0 {
+			min, err = time.ParseDuration(params[0])
+			if err != nil {
+				return false
+			}
+			if duration < min {
+				// the duration value is smaller than the min
+				return false
+			}
+			if len(params) > 1 {
+				max, err = time.ParseDuration(params[1])
+				if err != nil {
+					return false
+				}
+				if duration > max {
+					// the duration value is larger than the max
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
 // ValidateDtoUuid used to check the UpdateDTO uuid pointer value

--- a/dtos/autoevent.go
+++ b/dtos/autoevent.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +12,7 @@ import (
 // AutoEvent and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.1.0#/AutoEvent
 type AutoEvent struct {
-	Interval   string `json:"interval" validate:"required,edgex-dto-duration"`
+	Interval   string `json:"interval" validate:"required,edgex-dto-duration=1ms"` // min/max can be defined as params, ex. edgex-dto-duration=10ms0x2C24h
 	OnChange   bool   `json:"onChange"`
 	SourceName string `json:"sourceName" validate:"required"`
 }

--- a/dtos/interval.go
+++ b/dtos/interval.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,7 @@ type Interval struct {
 	Name        string `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Start       string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	End         string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
-	Interval    string `json:"interval" validate:"required,edgex-dto-duration"`
+	Interval    string `json:"interval" validate:"required,edgex-dto-duration=10ms"` // min/max can be defined as params, ex. edgex-dto-duration=10ms0x2C24h
 }
 
 // NewInterval creates interval DTO with required fields
@@ -32,7 +32,7 @@ type UpdateInterval struct {
 	Name     *string `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Start    *string `json:"start" validate:"omitempty,edgex-dto-interval-datetime"`
 	End      *string `json:"end" validate:"omitempty,edgex-dto-interval-datetime"`
-	Interval *string `json:"interval" validate:"omitempty,edgex-dto-duration"`
+	Interval *string `json:"interval" validate:"omitempty,edgex-dto-duration=10ms"` // min/max can be defined as params, ex. edgex-dto-duration=10ms0x2C24h
 }
 
 // NewUpdateInterval creates updateInterval DTO with required field


### PR DESCRIPTION
Add min/max params for edgex-dto-duration tag to define the allowed duration range, to define the allowed min scheduler/autoevent interval.

_The fix in Xpert is differnet from the one in https://github.com/edgexfoundry/edgex-go/issues/4586 which only adds warning logs when the interval is less than the minimum values._

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->