### PR TITLE
EDX-4229 Add http clients/dtos for Keeper registry

### DIFF
--- a/clients/http/registry.go
+++ b/clients/http/registry.go
@@ -1,0 +1,79 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package http
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http/utils"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+)
+
+var emptyResponse any
+
+// RegistryClient is the REST client for invoking the registry APIs(/registry/*) from Core Keeper
+type registryClient struct {
+	baseUrl string
+}
+
+// NewRegistryClient creates an instance of RegistryClient
+func NewRegistryClient(baseUrl string) interfaces.RegistryClient {
+	return &registryClient{
+		baseUrl: baseUrl,
+	}
+}
+
+// Register registers a service instance
+func (rc *registryClient) Register(ctx context.Context, req requests.AddRegistrationRequest) errors.EdgeX {
+	err := utils.PostRequestWithRawData(ctx, &emptyResponse, rc.baseUrl, common.ApiRegisterRoute, nil, req)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}
+
+// UpdateRegister updates the registration data of the service
+func (rc *registryClient) UpdateRegister(ctx context.Context, req requests.AddRegistrationRequest) errors.EdgeX {
+	err := utils.PutRequest(ctx, &emptyResponse, rc.baseUrl, common.ApiRegisterRoute, nil, req)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}
+
+// RegistrationByServiceId returns the registration data by service id
+func (rc *registryClient) RegistrationByServiceId(ctx context.Context, serviceId string) (responses.RegistrationResponse, errors.EdgeX) {
+	requestPath := utils.EscapeAndJoinPath(common.ApiRegisterRoute, common.ServiceId, serviceId)
+	res := responses.RegistrationResponse{}
+	err := utils.GetRequest(ctx, &res, rc.baseUrl, requestPath, nil)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// AllRegistry returns the registration data of all registered service
+func (rc *registryClient) AllRegistry(ctx context.Context) (responses.MultiRegistrationsResponse, errors.EdgeX) {
+	res := responses.MultiRegistrationsResponse{}
+	err := utils.GetRequest(ctx, &res, rc.baseUrl, common.ApiAllRegistrationsRoute, nil)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+// Deregister deregisters a service by service id
+func (rc *registryClient) Deregister(ctx context.Context, serviceId string) errors.EdgeX {
+	requestPath := utils.EscapeAndJoinPath(common.ApiRegisterRoute, common.ServiceId, serviceId)
+	err := utils.DeleteRequest(ctx, &emptyResponse, rc.baseUrl, requestPath)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}

--- a/clients/http/registry_test.go
+++ b/clients/http/registry_test.go
@@ -1,0 +1,71 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+
+	"github.com/stretchr/testify/require"
+)
+
+const mockServiceId = "mock-service"
+
+func TestRegister(t *testing.T) {
+	ts := newTestServer(http.MethodPost, common.ApiRegisterRoute, nil)
+	defer ts.Close()
+
+	client := NewRegistryClient(ts.URL)
+	err := client.Register(context.Background(), requests.AddRegistrationRequest{})
+
+	require.NoError(t, err)
+}
+
+func TestUpdateRegister(t *testing.T) {
+	ts := newTestServer(http.MethodPut, common.ApiRegisterRoute, nil)
+	defer ts.Close()
+
+	client := NewRegistryClient(ts.URL)
+	err := client.UpdateRegister(context.Background(), requests.AddRegistrationRequest{})
+
+	require.NoError(t, err)
+}
+
+func TestRegistrationByServiceId(t *testing.T) {
+	ts := newTestServer(http.MethodGet, common.ApiRegisterRoute+"/"+common.ServiceId+"/"+mockServiceId, responses.RegistrationResponse{})
+	defer ts.Close()
+
+	client := NewRegistryClient(ts.URL)
+	res, err := client.RegistrationByServiceId(context.Background(), mockServiceId)
+
+	require.NoError(t, err)
+	require.IsType(t, responses.RegistrationResponse{}, res)
+}
+
+func TestAllRegistry(t *testing.T) {
+	ts := newTestServer(http.MethodGet, common.ApiAllRegistrationsRoute, responses.MultiRegistrationsResponse{})
+	defer ts.Close()
+
+	client := NewRegistryClient(ts.URL)
+	res, err := client.AllRegistry(context.Background())
+
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiRegistrationsResponse{}, res)
+}
+
+func TestDeregister(t *testing.T) {
+	ts := newTestServer(http.MethodDelete, common.ApiRegisterRoute+"/"+common.ServiceId+"/"+mockServiceId, nil)
+	defer ts.Close()
+
+	client := NewRegistryClient(ts.URL)
+	err := client.Deregister(context.Background(), mockServiceId)
+
+	require.NoError(t, err)
+}

--- a/clients/interfaces/registry.go
+++ b/clients/interfaces/registry.go
@@ -1,0 +1,22 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+)
+
+// RegistryClient defines the interface for interactions with the registry endpoint on the Edge Xpert core-keeper service.
+type RegistryClient interface {
+	Register(context.Context, requests.AddRegistrationRequest) errors.EdgeX
+	UpdateRegister(context.Context, requests.AddRegistrationRequest) errors.EdgeX
+	RegistrationByServiceId(context.Context, string) (responses.RegistrationResponse, errors.EdgeX)
+	AllRegistry(context.Context) (responses.MultiRegistrationsResponse, errors.EdgeX)
+	Deregister(context.Context, string) errors.EdgeX
+}

--- a/common/constants.go
+++ b/common/constants.go
@@ -138,8 +138,11 @@ const (
 	ApiAllRulesRoute   = ApiRuleRoute + "/" + All
 	ApiRuleByNameRoute = ApiRuleRoute + "/" + Name + "/{" + Name + "}"
 
-	ApiKVSRoute      = ApiBase + "/kvs"
-	ApiKVSByKeyRoute = ApiKVSRoute + "/" + Key + "/{" + Key + "}"
+	ApiKVSRoute                     = ApiBase + "/kvs"
+	ApiKVSByKeyRoute                = ApiKVSRoute + "/" + Key + "/{" + Key + "}"
+	ApiRegisterRoute                = ApiBase + "/registry"
+	ApiAllRegistrationsRoute        = ApiRegisterRoute + "/" + All
+	ApiRegistrationByServiceIdRoute = ApiRegisterRoute + "/" + ServiceId + "/{" + ServiceId + "}"
 )
 
 // Constants related to defined url path names and parameters in the v2 service APIs
@@ -195,6 +198,7 @@ const (
 	Acknowledge   = "acknowledge"
 	Unacknowledge = "unacknowledge"
 	Key           = "key"
+	ServiceId     = "serviceId"
 
 	Offset      = "offset"         //query string to specify the number of items to skip before starting to collect the result set.
 	Limit       = "limit"          //query string to specify the numbers of items to return

--- a/dtos/registration.go
+++ b/dtos/registration.go
@@ -1,0 +1,85 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package dtos
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+)
+
+type Registration struct {
+	DBTimestamp   `json:",inline"`
+	ServiceId     string      `json:"serviceId"`
+	Status        string      `json:"status"`
+	Host          string      `json:"host"`
+	Port          int         `json:"port" `
+	HealthCheck   HealthCheck `json:",inline"`
+	LastConnected int64       `json:"lastConnected"`
+}
+
+type HealthCheck struct {
+	Interval string `json:"interval"`
+	Path     string `json:"path"`
+	Type     string `json:"type"`
+}
+
+func ToRegistrationModel(dto Registration) models.Registration {
+	var r models.Registration
+	r.ServiceId = dto.ServiceId
+	r.Status = dto.Status
+	r.Host = dto.Host
+	r.Port = dto.Port
+	r.LastConnected = dto.LastConnected
+	r.HealthCheck.Type = dto.HealthCheck.Type
+	r.HealthCheck.Path = dto.HealthCheck.Path
+	r.HealthCheck.Interval = dto.HealthCheck.Interval
+
+	return r
+}
+
+func FromRegistrationModelToDTO(r models.Registration) Registration {
+	var dto Registration
+	dto.DBTimestamp = DBTimestamp(r.DBTimestamp)
+	dto.ServiceId = r.ServiceId
+	dto.Status = r.Status
+	dto.Host = r.Host
+	dto.Port = r.Port
+	dto.LastConnected = r.LastConnected
+	dto.HealthCheck.Type = r.HealthCheck.Type
+	dto.HealthCheck.Path = r.HealthCheck.Path
+	dto.HealthCheck.Interval = r.HealthCheck.Interval
+
+	return dto
+}
+
+func (r *Registration) Validate() error {
+	// check if either the ServiceId, Port or HealthCheck.Type field is empty
+	if r.ServiceId == "" {
+		return errors.New(" the ServiceId field is empty")
+	}
+	if r.Port == 0 {
+		return errors.New(" the Port field is empty")
+	}
+	if r.HealthCheck.Type == "" {
+		return errors.New(" the HealthCheck Type field is empty")
+	}
+	// check if the Interval field is a valid duration string
+	_, err := time.ParseDuration(r.HealthCheck.Interval)
+	if err != nil {
+		return fmt.Errorf("health check interval is not in Go duration string format: %s", err.Error())
+	}
+	// check if the health status value is UP, DOWN or UNKNOWN
+	// if the value is invalid or empty, assign UNKNOWN to the status value
+	switch r.Status {
+	case models.Up, models.Down, models.Unknown:
+		break
+	default:
+		r.Status = models.Unknown
+	}
+	return nil
+}

--- a/dtos/registration_test.go
+++ b/dtos/registration_test.go
@@ -1,0 +1,94 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package dtos
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	serviceId       = "mock-service-id"
+	status          = "UP"
+	port            = 5959
+	host            = "edgex-mock-service"
+	interval        = "10s"
+	path            = "/api/v2/ping"
+	healthCheckType = "http"
+)
+
+var (
+	registration = Registration{
+		DBTimestamp: DBTimestamp{},
+		ServiceId:   serviceId,
+		Status:      status,
+		Host:        host,
+		Port:        port,
+		HealthCheck: HealthCheck{
+			Interval: interval,
+			Path:     path,
+			Type:     healthCheckType,
+		},
+	}
+	registrationModel = models.Registration{
+		DBTimestamp: models.DBTimestamp{},
+		ServiceId:   serviceId,
+		Status:      status,
+		Host:        host,
+		Port:        port,
+		HealthCheck: models.HealthCheck{
+			Interval: interval,
+			Path:     path,
+			Type:     healthCheckType,
+		},
+	}
+)
+
+func TestToRegistrationModel(t *testing.T) {
+	result := ToRegistrationModel(registration)
+	assert.Equal(t, registrationModel, result, "ToRegistrationModel did not result in registration model")
+}
+
+func TestFromRegistrationModelToDTO(t *testing.T) {
+	result := FromRegistrationModelToDTO(registrationModel)
+	assert.Equal(t, registration, result, "FromRegistrationModelToDTO did not result in registration dto")
+}
+
+func TestRegistration_Validate(t *testing.T) {
+	validRegistry := registration
+	emptyServiceId := validRegistry
+	emptyServiceId.ServiceId = ""
+	emptyPort := validRegistry
+	emptyPort.Port = 0
+	emptyHealthCheckType := validRegistry
+	emptyHealthCheckType.HealthCheck.Type = ""
+	invalidInterval := validRegistry
+	invalidInterval.HealthCheck.Interval = "xxx"
+
+	tests := []struct {
+		name        string
+		request     Registration
+		expectedErr bool
+	}{
+		{"valid Registration", validRegistry, false},
+		{"invalid Registration, empty service id", emptyServiceId, true},
+		{"invalid Registration, empty port", emptyPort, true},
+		{"invalid Registration, empty HealthCheck type", emptyHealthCheckType, true},
+		{"invalid Registration, invalid HealthCheck interval", invalidInterval, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/dtos/requests/registration.go
+++ b/dtos/requests/registration.go
@@ -1,0 +1,23 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package requests
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+)
+
+type AddRegistrationRequest struct {
+	common.BaseRequest `json:",inline"`
+	Registration       dtos.Registration `json:"registration"`
+}
+
+func (a *AddRegistrationRequest) Validate() error {
+	err := a.Registration.Validate()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/dtos/requests/registration_test.go
+++ b/dtos/requests/registration_test.go
@@ -1,0 +1,64 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package requests
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	dtoCommon "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddRegistrationRequest_Validate(t *testing.T) {
+	valid := AddRegistrationRequest{
+		BaseRequest: dtoCommon.BaseRequest{
+			RequestId:   ExampleUUID,
+			Versionable: dtoCommon.NewVersionable(),
+		},
+		Registration: dtos.Registration{
+			ServiceId: "mock-service-id",
+			Status:    "UNKNOWN",
+			Host:      "edgex-mock-service",
+			Port:      5959,
+			HealthCheck: dtos.HealthCheck{
+				Interval: "10s",
+				Path:     "/api/v2/ping",
+				Type:     "http",
+			},
+		},
+	}
+	emptyServiceId := valid
+	emptyServiceId.Registration.ServiceId = ""
+	emptyPort := valid
+	emptyPort.Registration.Port = 0
+	emptyHealthCheckType := valid
+	emptyHealthCheckType.Registration.HealthCheck.Type = ""
+	invalidInterval := valid
+	invalidInterval.Registration.HealthCheck.Interval = "xxx"
+
+	tests := []struct {
+		name        string
+		request     AddRegistrationRequest
+		expectedErr bool
+	}{
+		{"valid AddRegistrationRequest", valid, false},
+		{"invalid AddRegistrationRequest, empty service id", emptyServiceId, true},
+		{"invalid AddRegistrationRequest, empty port", emptyPort, true},
+		{"invalid AddRegistrationRequest, empty HealthCheck type", emptyHealthCheckType, true},
+		{"invalid AddRegistrationRequest, invalid HealthCheck interval", invalidInterval, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/dtos/responses/registration.go
+++ b/dtos/responses/registration.go
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package responses
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+)
+
+type RegistrationResponse struct {
+	common.BaseResponse `json:",inline"`
+	Registration        dtos.Registration `json:"registration"`
+}
+
+type MultiRegistrationsResponse struct {
+	common.BaseWithTotalCountResponse `json:",inline"`
+	Registrations                     []dtos.Registration `json:"registrations"`
+}
+
+func NewRegistrationResponse(requestId string, message string, statusCode int, r dtos.Registration) RegistrationResponse {
+	return RegistrationResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Registration: r,
+	}
+}
+
+func NewMultiRegistrationsResponse(requestId string, message string, statusCode int, totalCount uint32, registrations []dtos.Registration) MultiRegistrationsResponse {
+	return MultiRegistrationsResponse{
+		BaseWithTotalCountResponse: common.NewBaseWithTotalCountResponse(requestId, message, statusCode, totalCount),
+		Registrations:              registrations,
+	}
+}

--- a/dtos/responses/registration_test.go
+++ b/dtos/responses/registration_test.go
@@ -1,0 +1,49 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package responses
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	registration = dtos.Registration{
+		DBTimestamp: dtos.DBTimestamp{},
+		ServiceId:   "mock-service-id",
+		Status:      "UP",
+		Host:        "edgex-mock-service",
+		Port:        5959,
+		HealthCheck: dtos.HealthCheck{
+			Interval: "10s",
+			Path:     "/api/v2/ping",
+			Type:     "http",
+		},
+	}
+)
+
+func TestNewRegistrationResponse(t *testing.T) {
+	actual := NewRegistrationResponse(expectedRequestId, expectedMessage, expectedStatusCode, registration)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, registration, actual.Registration)
+}
+
+func TestNewMultiRegistrationsResponse(t *testing.T) {
+	expectedTotalCount := uint32(1)
+	expectedResp := []dtos.Registration{registration}
+	actual := NewMultiRegistrationsResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedTotalCount, expectedResp)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedTotalCount, actual.TotalCount)
+	assert.Equal(t, expectedResp, actual.Registrations)
+}

--- a/models/registration.go
+++ b/models/registration.go
@@ -1,0 +1,21 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+
+package models
+
+type Registration struct {
+	DBTimestamp
+	ServiceId     string
+	Status        string
+	Host          string
+	Port          int
+	HealthCheck   HealthCheck
+	LastConnected int64
+}
+
+type HealthCheck struct {
+	Interval string
+	Path     string
+	Type     string
+}


### PR DESCRIPTION
Add http clients/dtos for Keeper.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->