### PR TITLE
EDX-4242 Add UseRegistry field to OperationRequest DTO

### DIFF
--- a/dtos/requests/operation.go
+++ b/dtos/requests/operation.go
@@ -17,9 +17,9 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/system-agent/2.1.0#/OperationRequest
 type OperationRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
-	ServiceName           string `json:"serviceName" validate:"required"`
-	Action                string `json:"action" validate:"oneof='start' 'stop' 'restart' 'rm' 'inspect'"`
-	UseRegistry           string `json:"useRegistry"` // to identify whether the app service container will be started with the --registry flag
+	ServiceName           string   `json:"serviceName" validate:"required"`
+	Action                string   `json:"action" validate:"oneof='start' 'stop' 'restart' 'rm' 'inspect'"`
+	Flags                 []string `json:"flags"` // to identify whether the app service container will be started with additional flags
 }
 
 // Validate satisfies the Validator interface
@@ -34,7 +34,7 @@ func (o *OperationRequest) UnmarshalJSON(b []byte) error {
 		dtoCommon.BaseRequest
 		ServiceName string
 		Action      string
-		UseRegistry string
+		Flags       []string
 	}{}
 
 	if err := json.Unmarshal(b, &alias); err != nil {

--- a/dtos/requests/operation.go
+++ b/dtos/requests/operation.go
@@ -1,7 +1,6 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
-// SPDX-License-Identifier: Apache-2.0
 
 package requests
 
@@ -20,6 +19,7 @@ type OperationRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
 	ServiceName           string `json:"serviceName" validate:"required"`
 	Action                string `json:"action" validate:"oneof='start' 'stop' 'restart' 'rm' 'inspect'"`
+	UseRegistry           string `json:"useRegistry"` // to identify whether the app service container will be started with the --registry flag
 }
 
 // Validate satisfies the Validator interface
@@ -34,6 +34,7 @@ func (o *OperationRequest) UnmarshalJSON(b []byte) error {
 		dtoCommon.BaseRequest
 		ServiceName string
 		Action      string
+		UseRegistry string
 	}{}
 
 	if err := json.Unmarshal(b, &alias); err != nil {

--- a/dtos/requests/operation.go
+++ b/dtos/requests/operation.go
@@ -18,8 +18,8 @@ import (
 type OperationRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
 	ServiceName           string   `json:"serviceName" validate:"required"`
-	Action                string   `json:"action" validate:"oneof='start' 'stop' 'restart' 'rm' 'inspect'"`
-	Flags                 []string `json:"flags"` // to identify whether the app service container will be started with additional flags
+	Action                string   `json:"action" validate:"required"`
+	CmdFlags              []string `json:"cmdFlags"` // to identify the additional CMD flags or argument of an OCI operation
 }
 
 // Validate satisfies the Validator interface
@@ -34,7 +34,7 @@ func (o *OperationRequest) UnmarshalJSON(b []byte) error {
 		dtoCommon.BaseRequest
 		ServiceName string
 		Action      string
-		Flags       []string
+		CmdFlags    []string
 	}{}
 
 	if err := json.Unmarshal(b, &alias); err != nil {

--- a/dtos/requests/operation.go
+++ b/dtos/requests/operation.go
@@ -19,7 +19,7 @@ type OperationRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
 	ServiceName           string   `json:"serviceName" validate:"required"`
 	Action                string   `json:"action" validate:"required"`
-	CmdFlags              []string `json:"cmdFlags"` // to identify the additional CMD flags or argument of an OCI operation
+	CmdFlags              []string `json:"cmdFlags"` // to identify the additional CMD flags or argument of a CRI operation
 }
 
 // Validate satisfies the Validator interface

--- a/dtos/requests/operation_test.go
+++ b/dtos/requests/operation_test.go
@@ -34,8 +34,6 @@ func TestOperationRequest_Validate(t *testing.T) {
 	noServiceName.ServiceName = ""
 	noAction := testOperationRequest
 	noAction.Action = ""
-	invalidAction := testOperationRequest
-	invalidAction.Action = "remove"
 
 	tests := []struct {
 		name        string
@@ -47,7 +45,6 @@ func TestOperationRequest_Validate(t *testing.T) {
 		{"invalid - RequestId is not an uuid", invalidReqId, true},
 		{"invalid - no ServiceName", noServiceName, true},
 		{"invalid - no Action", noAction, true},
-		{"invalid - invalid Action", invalidAction, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Add UseRegistry field to identify whether app service should be started with --registry flag.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->