### PR TITLE
EDX-4301 Add HALT status constant for Keeper

### DIFF
--- a/dtos/registration.go
+++ b/dtos/registration.go
@@ -73,10 +73,10 @@ func (r *Registration) Validate() error {
 	if err != nil {
 		return fmt.Errorf("health check interval is not in Go duration string format: %s", err.Error())
 	}
-	// check if the health status value is UP, DOWN or UNKNOWN
+	// check if the health status value is UP, DOWN, UNKNOWN, or HALT
 	// if the value is invalid or empty, assign UNKNOWN to the status value
 	switch r.Status {
-	case models.Up, models.Down, models.Unknown:
+	case models.Up, models.Down, models.Unknown, models.Halt:
 		break
 	default:
 		r.Status = models.Unknown

--- a/models/consts.go
+++ b/models/consts.go
@@ -50,3 +50,6 @@ const (
 	Down    = "DOWN"
 	Unknown = "UNKNOWN"
 )
+
+// Constant for Keeper health status
+const Halt = "HALT"


### PR DESCRIPTION
Add HALT health status constant for Keeper and validation check.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->