### PR TITLE
PS-547-3 Use original CAN ID in DBC translation

### DIFF
--- a/central/dbc/constants.go
+++ b/central/dbc/constants.go
@@ -21,4 +21,6 @@ const (
 	MuxSignal     = "muxSignal"
 	MuxNum        = "muxNum"
 	IsSigned      = "isSigned"
+
+	messageIDExtendedFlag = 0x80000000
 )

--- a/central/dbc/transform.go
+++ b/central/dbc/transform.go
@@ -120,7 +120,7 @@ func ConvertDBCtoDevice(data []byte, networkName, serviceName string) (deviceDTO
 				Canbus: {
 					Network:  networkName,
 					Standard: J1939,
-					ID:       strconv.Itoa(int(m.ID)),
+					ID:       getOriginalCanId(m.ID),
 					DataSize: strconv.Itoa(int(m.Length)),
 					Sender:   m.SenderNode,
 				},
@@ -134,4 +134,9 @@ func ConvertDBCtoDevice(data []byte, networkName, serviceName string) (deviceDTO
 		}
 	}
 	return
+}
+
+func getOriginalCanId(canID uint32) string {
+	id := canID | messageIDExtendedFlag
+	return strconv.FormatUint(uint64(id), 10)
 }

--- a/central/dbc/transform_test.go
+++ b/central/dbc/transform_test.go
@@ -47,7 +47,7 @@ func TestConvertDBCtoDevice(t *testing.T) {
 			Canbus: {
 				Network:  networkName,
 				Standard: J1939,
-				ID:       "217056254",
+				ID:       "2364539902",
 				DataSize: "8",
 				Sender:   "Vector__XXX",
 			},


### PR DESCRIPTION
The library removed the Extended Flag from the CAN ID. We need to add it back to ensure that the CAN ID remains consistent with the DBC file.
