### PR TITLE
EDX-4491 Allow no data row defined on the DeviceCommand sheet

### DIFF
--- a/central/xlsx/deviceprofile.go
+++ b/central/xlsx/deviceprofile.go
@@ -195,7 +195,8 @@ func (dpXlsx *deviceProfileXlsx) convertDeviceCommands(convertedProfile *dtos.De
 	if len(rows) >= 2 {
 		header = rows[0]
 	} else {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("at least 2 rows need to be defined in %s worksheet", deviceCommandSheetName), nil)
+		// not enough row defined in the DeviceCommand sheet, skip the following code and return
+		return nil
 	}
 
 	// parse the Device Command data rows

--- a/central/xlsx/deviceprofile_test.go
+++ b/central/xlsx/deviceprofile_test.go
@@ -282,7 +282,7 @@ func Test_DeviceProfile_convertDeviceCommands(t *testing.T) {
 		expectError         bool
 		expectValidateError bool
 	}{
-		{"convertDeviceCommands with row count less than 2", nil, true, false},
+		{"convertDeviceCommands with row count less than 2", []any{}, false, false},
 		{"convertDeviceCommands - success", validDeviceCommandRow, false, false},
 		{"convertDeviceCommands - invalid IsHidden", invalidIsHiddenRow, true, false},
 		{"convertDeviceCommands - invalid ReadWrite", invalidReadWriteRow, false, true},
@@ -311,8 +311,10 @@ func Test_DeviceProfile_convertDeviceCommands(t *testing.T) {
 					require.NotNil(t, dpX.GetValidateErrors(), "Expected convertDeviceCommands validation error not generated")
 				} else {
 					require.Equal(t, emptyValidateErr, dpX.GetValidateErrors(), "Unexpected convertDeviceCommands validation error")
-					require.Equal(t, 1, len(convertedProfile.DeviceCommands))
-					require.Equal(t, tt.dataRow[0], convertedProfile.DeviceCommands[0].Name)
+					if len(convertedProfile.DeviceCommands) > 0 {
+						require.Equal(t, 1, len(convertedProfile.DeviceCommands))
+						require.Equal(t, tt.dataRow[0], convertedProfile.DeviceCommands[0].Name)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
Allow no data row defined on the DeviceCommand sheet without returing error.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->