### PR TITLE
EDX-4494 Check the cell header belongs to attr field

### DIFF
--- a/central/xlsx/reader.go
+++ b/central/xlsx/reader.go
@@ -291,9 +291,12 @@ func convertResourcesFields(rowElement *reflect.Value, xlsxRow []string, headerC
 	for colIndex, cell := range xlsxRow {
 		headerName, field := getStructFieldByHeader(rowElement, colIndex, headerCol)
 		fieldValue := strings.TrimSpace(cell)
-		if fieldValue == "" {
-			// set fieldValue to 'default value' defined in mapping Table if not empty
-			if mapping, ok := fieldMappings[headerName]; ok && mapping.defaultValue != "" {
+
+		var fieldMapping mappingField
+		// set fieldValue to 'default value' defined in mapping Table if not empty
+		if mapping, ok := fieldMappings[headerName]; ok {
+			fieldMapping = mapping
+			if fieldValue == "" && mapping.defaultValue != "" {
 				fieldValue = mapping.defaultValue
 			}
 		}
@@ -313,8 +316,8 @@ func convertResourcesFields(rowElement *reflect.Value, xlsxRow []string, headerC
 					return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("error occurred on '%s' column", headerName), err)
 				}
 			} else {
-				// set the cell to Attributes map if header not belongs to Properties field
-				if fieldValue != "" {
+				// set the cell to Attributes map if header not belongs to Properties field and mapping path contains 'attributes'
+				if fieldValue != "" && strings.Contains(strings.ToLower(fieldMapping.path), strings.ToLower(attributes)) {
 					attrMapField := rowElement.FieldByName(attributes)
 					if attrMapField.Len() == 0 {
 						// initialize the Attributes map


### PR DESCRIPTION
Check the cell header belongs to attribute field from MappingTable before converting to DeviceResource.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->