### PR TITLE
EDX-4649 Add "IOTech_" prefix constant

### DIFF
--- a/common/central_constants.go
+++ b/common/central_constants.go
@@ -3,6 +3,8 @@
 package common
 
 const (
+	IOTechPrefix = "IOTech_"
+
 	ContextKeyContentType contextKey = ContentType
 	ContentTypeCSV                   = "text/csv"
 

--- a/v2models/autoevent.go
+++ b/v2models/autoevent.go
@@ -1,0 +1,15 @@
+//
+// Copyright (C) 2020-2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v2models
+
+// AutoEvent and its properties are defined in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/AutoEvent
+// Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
+type AutoEvent struct {
+	Interval   string
+	OnChange   bool
+	SourceName string
+}

--- a/v2models/device.go
+++ b/v2models/device.go
@@ -1,0 +1,43 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v2models
+
+// Device and its properties are defined in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/Device
+// Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
+type Device struct {
+	DBTimestamp
+	Id             string
+	Name           string
+	Description    string
+	AdminState     AdminState
+	OperatingState OperatingState
+	ProtocolName   string
+	Protocols      map[string]ProtocolProperties
+	LastConnected  int64 // Deprecated: will be replaced by Metrics in v3
+	LastReported   int64 // Deprecated: will be replaced by Metrics in v3
+	Labels         []string
+	Location       interface{}
+	Tags           map[string]interface{}
+	ServiceName    string
+	ProfileName    string
+	AutoEvents     []AutoEvent
+	Notify         bool
+	// Properties are required for device discovery, the feedback from JCI was that when discovering a device they
+	// want as much info as we can find about the device (so for example in a big system they have a better idea of what
+	// actual device is being provisioned). So we added a properties field to carry this information. IMHO this is a valid
+	// generic requirement to support discovery.
+	Properties map[string]any
+}
+
+// ProtocolProperties contains the device connection information in key/value pair
+type ProtocolProperties map[string]string
+
+// AdminState controls the range of values which constitute valid administrative states for a device
+type AdminState string
+
+// OperatingState is an indication of the operations of the device.
+type OperatingState string

--- a/xrtmodels/deviceInfo.go
+++ b/xrtmodels/deviceInfo.go
@@ -10,14 +10,39 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/v2models"
 )
 
 type DeviceInfo struct {
 	dtos.Device
 }
 
-// ToEdgeXV2Device converts the XRT model to EdgeX model
-func ToEdgeXV2Device(device DeviceInfo, serviceName string) models.Device {
+// ToEdgeXV2Device converts the XRT model to EdgeX v2 model
+func ToEdgeXV2Device(device DeviceInfo, serviceName string) v2models.Device {
+	protocols := make(map[string]v2models.ProtocolProperties)
+	protocolName := ""
+	for protocol, protocolProperties := range device.Protocols {
+		protocols[protocol] = toEdgeXProperties(protocol, protocolProperties)
+		protocolName = strings.ToLower(protocol)
+	}
+	return v2models.Device{
+		Name:           device.Name,
+		Description:    "",
+		AdminState:     models.Unlocked,
+		OperatingState: models.Up,
+		ProtocolName:   protocolName,
+		Protocols:      protocols,
+		Labels:         nil,
+		Location:       nil,
+		ServiceName:    serviceName,
+		ProfileName:    device.ProfileName,
+		AutoEvents:     nil,
+		Properties:     device.Properties,
+	}
+}
+
+// ToEdgeXV3Device converts the XRT model to EdgeX v3 model
+func ToEdgeXV3Device(device DeviceInfo, serviceName string) models.Device {
 	protocolName := ""
 	for protocol, _ := range device.Protocols {
 		protocolName = strings.ToLower(protocol)


### PR DESCRIPTION
Add "IOTech_" prefix to all the first level Device properties we use.
- Add "IOTech_" prefix constant
- Add v2 device model
