### PR TITLE
EDX-4537 Filter out empty column for DeviceCmd

### DIFF
--- a/central/xlsx/deviceprofile.go
+++ b/central/xlsx/deviceprofile.go
@@ -206,19 +206,31 @@ func (dpXlsx *deviceProfileXlsx) convertDeviceCommands(convertedProfile *dtos.De
 			continue
 		}
 
-		// parse the DeviceCommand data columns
-		convertedDC := dtos.DeviceCommand{}
-		_, err = readStruct(&convertedDC, header, col, dpXlsx.fieldMappings)
-		if err != nil {
-			return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to unmarshal an xlsx column into DeviceCommand DTO", err)
+		// check if the column has any non-empty cell
+		// if yes, convert the xlsx column to DeviceCommand DTO
+		nonEmptyCol := false
+		for _, rowCell := range col {
+			if rowCell != "" {
+				nonEmptyCol = true
+				break
+			}
 		}
 
-		// validate the DeviceCommand DTO
-		err = common.Validate(convertedDC)
-		if err != nil {
-			dpXlsx.validateErrors[validateErrCommandPrefix+convertedDC.Name] = err
-		} else {
-			convertedProfile.DeviceCommands = append(convertedProfile.DeviceCommands, convertedDC)
+		if nonEmptyCol {
+			// parse the DeviceCommand data columns
+			convertedDC := dtos.DeviceCommand{}
+			_, err = readStruct(&convertedDC, header, col, dpXlsx.fieldMappings)
+			if err != nil {
+				return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to unmarshal an xlsx column into DeviceCommand DTO", err)
+			}
+
+			// validate the DeviceCommand DTO
+			err = common.Validate(convertedDC)
+			if err != nil {
+				dpXlsx.validateErrors[validateErrCommandPrefix+convertedDC.Name] = err
+			} else {
+				convertedProfile.DeviceCommands = append(convertedProfile.DeviceCommands, convertedDC)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Filter out empty column for xlsx DeviceCmd conversion. Only convert non-empty column.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->