### PR TITLE
EDX-4650 Move customized ProvisionWatcher fields to properties

### DIFF
--- a/common/central_constants.go
+++ b/common/central_constants.go
@@ -136,3 +136,14 @@ const (
 	TCP    = "tcp"
 	TCPS   = "tcps"
 )
+
+// Constants related for provisionWatcher discoveredDevice
+const (
+	ProtocolName       = IOTechPrefix + "ProtocolName"
+	DeviceNamePattern  = IOTechPrefix + "DeviceNamePattern"
+	DeviceDescription  = IOTechPrefix + "DeviceDescription"
+	DeviceLabels       = IOTechPrefix + "DeviceLabels"
+	ProfileNamePattern = IOTechPrefix + "ProfileNamePattern"
+	ProfileDescription = IOTechPrefix + "ProfileDescription"
+	ProfileLabels      = IOTechPrefix + "ProfileLabels"
+)

--- a/dtos/provisionwatcher.go
+++ b/dtos/provisionwatcher.go
@@ -19,17 +19,6 @@ type ProvisionWatcher struct {
 	BlockingIdentifiers map[string][]string `json:"blockingIdentifiers,omitempty" yaml:"blockingIdentifiers,omitempty"`
 	AdminState          string              `json:"adminState" yaml:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	DiscoveredDevice    DiscoveredDevice    `json:"discoveredDevice" yaml:"discoveredDevice"`
-
-	ProtocolName       string      `json:"protocolName,omitempty" validate:"omitempty,edgex-dto-rfc3986-unreserved-chars"`
-	AutoEvents         []AutoEvent `json:"autoEvents,omitempty" validate:"dive"`
-	DeviceNameTemplate string      `json:"deviceNameTemplate,omitempty" validate:"omitempty"`
-	DeviceDescription  string      `json:"deviceDescription,omitempty"`
-	DeviceLabels       []string    `json:"deviceLabels,omitempty"`
-
-	ProfileName         string   `json:"profileName" validate:"omitempty,edgex-dto-no-reserved-chars"`
-	ProfileNameTemplate string   `json:"profileNameTemplate,omitempty" validate:"omitempty,edgex-dto-no-reserved-chars"`
-	ProfileDescription  string   `json:"profileDescription,omitempty"`
-	ProfileLabels       []string `json:"profileLabels,omitempty"`
 }
 
 type UpdateProvisionWatcher struct {
@@ -41,17 +30,6 @@ type UpdateProvisionWatcher struct {
 	BlockingIdentifiers map[string][]string    `json:"blockingIdentifiers"`
 	AdminState          *string                `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	DiscoveredDevice    UpdateDiscoveredDevice `json:"discoveredDevice"`
-
-	ProtocolName       *string     `json:"protocolName" validate:"omitempty,len=0|edgex-dto-rfc3986-unreserved-chars"`
-	AutoEvents         []AutoEvent `json:"autoEvents" validate:"dive"`
-	DeviceNameTemplate *string     `json:"deviceNameTemplate" validate:"omitempty"`
-	DeviceDescription  *string     `json:"deviceDescription"`
-	DeviceLabels       []string    `json:"deviceLabels"`
-
-	ProfileName         *string  `json:"profileName" validate:"omitempty,len=0|edgex-dto-no-reserved-chars"`
-	ProfileNameTemplate *string  `json:"profileNameTemplate" validate:"omitempty,len=0|edgex-dto-no-reserved-chars"`
-	ProfileDescription  *string  `json:"profileDescription"`
-	ProfileLabels       []string `json:"profileLabels"`
 }
 
 // ToProvisionWatcherModel transforms the ProvisionWatcher DTO to the ProvisionWatcher model
@@ -66,17 +44,6 @@ func ToProvisionWatcherModel(dto ProvisionWatcher) models.ProvisionWatcher {
 		BlockingIdentifiers: dto.BlockingIdentifiers,
 		AdminState:          models.AdminState(dto.AdminState),
 		DiscoveredDevice:    ToDiscoveredDeviceModel(dto.DiscoveredDevice),
-
-		ProtocolName:       dto.ProtocolName,
-		AutoEvents:         ToAutoEventModels(dto.AutoEvents),
-		DeviceNameTemplate: dto.DeviceNameTemplate,
-		DeviceDescription:  dto.DeviceDescription,
-		DeviceLabels:       dto.DeviceLabels,
-
-		ProfileName:         dto.ProfileName,
-		ProfileNameTemplate: dto.ProfileNameTemplate,
-		ProfileDescription:  dto.ProfileDescription,
-		ProfileLabels:       dto.ProfileLabels,
 	}
 }
 
@@ -92,17 +59,6 @@ func FromProvisionWatcherModelToDTO(pw models.ProvisionWatcher) ProvisionWatcher
 		BlockingIdentifiers: pw.BlockingIdentifiers,
 		AdminState:          string(pw.AdminState),
 		DiscoveredDevice:    FromDiscoveredDeviceModelToDTO(pw.DiscoveredDevice),
-
-		ProtocolName:       pw.ProtocolName,
-		AutoEvents:         FromAutoEventModelsToDTOs(pw.AutoEvents),
-		DeviceNameTemplate: pw.DeviceNameTemplate,
-		DeviceDescription:  pw.DeviceDescription,
-		DeviceLabels:       pw.DeviceLabels,
-
-		ProfileName:         pw.ProfileName,
-		ProfileNameTemplate: pw.ProfileNameTemplate,
-		ProfileDescription:  pw.ProfileDescription,
-		ProfileLabels:       pw.ProfileLabels,
 	}
 }
 
@@ -118,17 +74,6 @@ func FromProvisionWatcherModelToUpdateDTO(pw models.ProvisionWatcher) UpdateProv
 		BlockingIdentifiers: pw.BlockingIdentifiers,
 		AdminState:          &adminState,
 		DiscoveredDevice:    FromDiscoveredDeviceModelToUpdateDTO(pw.DiscoveredDevice),
-
-		ProtocolName:       &pw.ProtocolName,
-		AutoEvents:         FromAutoEventModelsToDTOs(pw.AutoEvents),
-		DeviceNameTemplate: &pw.DeviceNameTemplate,
-		DeviceDescription:  &pw.DeviceDescription,
-		DeviceLabels:       pw.DeviceLabels,
-
-		ProfileName:         &pw.ProfileName,
-		ProfileNameTemplate: &pw.ProfileNameTemplate,
-		ProfileLabels:       pw.ProfileLabels,
-		ProfileDescription:  &pw.ProfileDescription,
 	}
 	return dto
 }

--- a/dtos/provisionwatcher_test.go
+++ b/dtos/provisionwatcher_test.go
@@ -27,12 +27,4 @@ func TestFromProvisionWatcherModelToUpdateDTO(t *testing.T) {
 	assert.EqualValues(t, model.DiscoveredDevice.AdminState, *dto.DiscoveredDevice.AdminState)
 	assert.Zero(t, model.DiscoveredDevice.AutoEvents)
 	assert.Equal(t, model.DiscoveredDevice.Properties, dto.DiscoveredDevice.Properties)
-
-	assert.Equal(t, model.DeviceNameTemplate, *dto.DeviceNameTemplate)
-	assert.Equal(t, model.ProfileName, *dto.ProfileName)
-	assert.EqualValues(t, model.ProtocolName, *dto.ProtocolName)
-	assert.EqualValues(t, model.DeviceDescription, *dto.DeviceDescription)
-	assert.Equal(t, model.ProfileNameTemplate, *dto.ProfileNameTemplate)
-	assert.Equal(t, model.ProfileLabels, dto.ProfileLabels)
-	assert.Equal(t, model.ProfileDescription, *dto.ProfileDescription)
 }

--- a/dtos/requests/provisionwatcher.go
+++ b/dtos/requests/provisionwatcher.go
@@ -115,28 +115,6 @@ func ReplaceProvisionWatcherModelFieldsWithDTO(pw *models.ProvisionWatcher, patc
 	if patch.DiscoveredDevice.Properties != nil {
 		pw.DiscoveredDevice.Properties = patch.DiscoveredDevice.Properties
 	}
-
-	if patch.DeviceNameTemplate != nil {
-		pw.DeviceNameTemplate = *patch.DeviceNameTemplate
-	}
-	if patch.ProtocolName != nil {
-		pw.ProtocolName = *patch.ProtocolName
-	}
-	if patch.DeviceDescription != nil {
-		pw.DeviceDescription = *patch.DeviceDescription
-	}
-	if patch.DeviceLabels != nil {
-		pw.DeviceLabels = patch.DeviceLabels
-	}
-	if patch.ProfileNameTemplate != nil {
-		pw.ProfileNameTemplate = *patch.ProfileNameTemplate
-	}
-	if patch.ProfileLabels != nil {
-		pw.ProfileLabels = patch.ProfileLabels
-	}
-	if patch.ProfileDescription != nil {
-		pw.ProfileDescription = *patch.ProfileDescription
-	}
 }
 
 func NewAddProvisionWatcherRequest(dto dtos.ProvisionWatcher) AddProvisionWatcherRequest {

--- a/dtos/requests/provisionwatcher_test.go
+++ b/dtos/requests/provisionwatcher_test.go
@@ -28,8 +28,8 @@ var testBlockingIdentifiers = map[string][]string{
 	"port": {"397", "398", "399"},
 }
 var testDeviceDescription = "test device description"
-var testDeviceNameTemplate = "device-name-{{Address}}-{{Port}}"
-var testProfileNameTemplate = "profile-name-{{Address}}-{{Port}}"
+var testDeviceNamePattern = "device-name-{{Address}}-{{Port}}"
+var testProfileNamePattern = "profile-name-{{Address}}-{{Port}}"
 var testProfileDescription = "test profile description"
 var testAddProvisionWatcher = AddProvisionWatcherRequest{
 	BaseRequest: common.BaseRequest{
@@ -76,14 +76,6 @@ func mockUpdateProvisionWatcher() dtos.UpdateProvisionWatcher {
 	d.DiscoveredDevice.ProfileName = &testProfileName
 	d.DiscoveredDevice.AdminState = &testAdminState
 	d.DiscoveredDevice.AutoEvents = testAutoEvents
-
-	d.DeviceNameTemplate = &testDeviceNameTemplate
-	d.ProtocolName = &testProtocolName
-	d.DeviceDescription = &testDeviceDescription
-	d.DeviceLabels = testDeviceLabels
-	d.ProfileNameTemplate = &testProfileNameTemplate
-	d.ProfileLabels = testLabels
-	d.ProfileDescription = &testProfileDescription
 	return d
 }
 
@@ -202,7 +194,6 @@ func TestAddProvisionWatcherReqToProvisionWatcherModels(t *testing.T) {
 				"port": {"397", "398", "399"},
 			},
 			AdminState: models.Locked,
-			AutoEvents: make([]models.AutoEvent, 0),
 			DiscoveredDevice: models.DiscoveredDevice{
 				ProfileName: TestDeviceProfileName,
 				AdminState:  models.Locked,
@@ -370,12 +361,4 @@ func TestReplaceProvisionWatcherModelFieldsWithDTO(t *testing.T) {
 	assert.Equal(t, TestDeviceProfileName, provisionWatcher.DiscoveredDevice.ProfileName)
 	assert.Equal(t, models.AdminState(models.Locked), provisionWatcher.AdminState)
 	assert.Equal(t, dtos.ToAutoEventModels(testAutoEvents), provisionWatcher.DiscoveredDevice.AutoEvents)
-
-	assert.Equal(t, testProtocolName, provisionWatcher.ProtocolName)
-	assert.Equal(t, testDeviceDescription, provisionWatcher.DeviceDescription)
-	assert.Equal(t, testDeviceNameTemplate, provisionWatcher.DeviceNameTemplate)
-	assert.Equal(t, testDeviceLabels, provisionWatcher.DeviceLabels)
-	assert.Equal(t, testProfileNameTemplate, provisionWatcher.ProfileNameTemplate)
-	assert.Equal(t, testLabels, provisionWatcher.ProfileLabels)
-	assert.Equal(t, testProfileDescription, provisionWatcher.ProfileDescription)
 }

--- a/models/central.go
+++ b/models/central.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2024 IOTech Ltd
+
+package models
+
+import (
+	"fmt"
+)
+
+func (d DiscoveredDevice) StrValueFromProperties(key string) string {
+	val := ""
+	if propVal, ok := d.Properties[key]; ok {
+		val = fmt.Sprintf("%v", propVal)
+	}
+	return val
+}
+
+func (d DiscoveredDevice) StrSliceFromProperties(key string) []string {
+	if propVal, ok := d.Properties[key]; ok {
+		switch slice := propVal.(type) {
+		case []string:
+			return slice
+		case []any:
+			strSlice := make([]string, len(slice))
+			for i, v := range slice {
+				strSlice[i] = fmt.Sprintf("%v", v)
+			}
+			return strSlice
+		}
+	}
+	return []string{}
+}

--- a/models/provisionwatcher.go
+++ b/models/provisionwatcher.go
@@ -15,17 +15,4 @@ type ProvisionWatcher struct {
 	BlockingIdentifiers map[string][]string
 	AdminState          AdminState
 	DiscoveredDevice    DiscoveredDevice
-
-	// Central
-	ProfileName        string
-	ProtocolName       string
-	AutoEvents         []AutoEvent
-
-	DeviceNameTemplate string
-	DeviceDescription  string
-	DeviceLabels       []string
-
-	ProfileNameTemplate string
-	ProfileDescription  string
-	ProfileLabels       []string
 }


### PR DESCRIPTION
Move all the customized ProvisionWatcher fields to properties field
- Also add “IOTech_” prefix to the first level of properties
- Rename all the “NameTemplate” to “NamePattern”
