### PR TITLE
EDX-4786 Remove xrt protocol properties dataType conversion

### DIFF
--- a/dtos/event_test.go
+++ b/dtos/event_test.go
@@ -107,7 +107,10 @@ func TestEvent_ToXML(t *testing.T) {
 		"<Readings><Id>7a1707f0-166f-4c4b-bc9d-1d54c74e0137</Id><Origin>1594963842</Origin><DeviceName>TestDevice</DeviceName><Tags>",
 		"<1>TestTag1</1>",
 		"<2>TestTag2</2>",
-		"</Tags><ResourceName>TestSourceName</ResourceName><ProfileName>TestDeviceProfileName</ProfileName><ValueType>Int8</ValueType><Units></Units><Tags><1>TestTag1</1><2>TestTag2</2></Tags><BinaryValue></BinaryValue><MediaType></MediaType><Value></Value></Readings>",
+		"</Tags><ResourceName>TestSourceName</ResourceName><ProfileName>TestDeviceProfileName</ProfileName><ValueType>Int8</ValueType><Units></Units><Tags>",
+		"<1>TestTag1</1>",
+		"<2>TestTag2</2>",
+		"</Tags><BinaryValue></BinaryValue><MediaType></MediaType><Value></Value></Readings>",
 	}
 	actual, _ := expectedDTO.ToXML()
 	for _, item := range contains {

--- a/xrtmodels/deviceInfo.go
+++ b/xrtmodels/deviceInfo.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2024 IOTech Ltd
 
 package xrtmodels
 
@@ -70,14 +70,6 @@ func ToXrtDevice(device models.Device) (deviceInfo DeviceInfo, edgexErr errors.E
 	err = json.Unmarshal(deviceData, &deviceInfo)
 	if err != nil {
 		return deviceInfo, errors.NewCommonEdgeXWrapper(err)
-	}
-
-	// Convert the EdgeX protocol properties to xrt protocol properties
-	for protocol, v := range deviceInfo.Protocols {
-		err = toXrtProperties(protocol, v)
-		if err != nil {
-			return deviceInfo, errors.NewCommonEdgeXWrapper(err)
-		}
 	}
 
 	// Process the specified protocol for XRT

--- a/xrtmodels/xrtconv.go
+++ b/xrtmodels/xrtconv.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 IOTech Ltd
+// Copyright (C) 2022-2024 IOTech Ltd
 
 package xrtmodels
 
@@ -12,47 +12,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 )
-
-func toXrtProperties(protocol string, protocolProperties map[string]interface{}) errors.EdgeX {
-	intProperties, floatProperties, boolProperties := propertyConversionList(protocol)
-
-	for _, p := range intProperties {
-		propertyValue, ok := protocolProperties[p]
-		if ok {
-			// convert property value from interface{} to string, then to int
-			val, err := strconv.Atoi(fmt.Sprintf("%v", propertyValue))
-			if err != nil {
-				return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("fail to convert %v to int", p), err)
-			}
-			protocolProperties[p] = int(val)
-		}
-	}
-
-	for _, p := range floatProperties {
-		propertyValue, ok := protocolProperties[p]
-		if ok {
-			// convert property value from interface{} to string, then to float
-			val, err := strconv.ParseFloat(fmt.Sprintf("%v", propertyValue), 64)
-			if err != nil {
-				return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("fail to convert %v to float", p), err)
-			}
-			protocolProperties[p] = val
-		}
-	}
-
-	for _, p := range boolProperties {
-		propertyValue, ok := protocolProperties[p]
-		if ok {
-			// convert property value from interface{} to string, then to bool
-			val, err := strconv.ParseBool(fmt.Sprintf("%v", propertyValue))
-			if err != nil {
-				return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("fail to convert %v to bool", p), err)
-			}
-			protocolProperties[p] = val
-		}
-	}
-	return nil
-}
 
 func toEdgeXProperties(protocol string, protocolProperties map[string]any) map[string]string {
 	intProperties, floatProperties, boolProperties := propertyConversionList(protocol)

--- a/xrtmodels/xrtconv_test.go
+++ b/xrtmodels/xrtconv_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 IOTech Ltd
+// Copyright (C) 2022-2024 IOTech Ltd
 
 package xrtmodels
 
@@ -20,7 +20,7 @@ func TestToXrtDevice(t *testing.T) {
 		Name: deviceName,
 		Protocols: map[string]models.ProtocolProperties{
 			common.BacnetIP: {
-				common.BacnetDeviceInstance: "1234",
+				common.BacnetDeviceInstance: 1234,
 			},
 		},
 		ProfileName:    profileName,
@@ -36,219 +36,11 @@ func TestToXrtDevice(t *testing.T) {
 
 	assert.Equal(t, deviceName, xrtDevice.Name)
 	assert.Equal(t, common.BacnetIP, xrtDevice.Properties[common.ProtocolName])
-	assert.Equal(t, 1234, xrtDevice.Protocols[common.BacnetIP][common.BacnetDeviceInstance])
+	assert.Equal(t, float64(1234), xrtDevice.Protocols[common.BacnetIP][common.BacnetDeviceInstance])
 	assert.Equal(t, profileName, xrtDevice.ProfileName)
 	assert.Equal(t, serviceName, xrtDevice.ServiceName)
 	assert.Equal(t, models.Unlocked, xrtDevice.AdminState)
 	assert.Equal(t, models.Up, xrtDevice.OperatingState)
-}
-
-func TestToXrtProperties(t *testing.T) {
-	tests := []struct {
-		protocol   string
-		properties map[string]interface{}
-		expected   map[string]interface{}
-	}{
-		{
-			protocol: common.BacnetIP,
-			properties: map[string]interface{}{
-				common.BacnetDeviceInstance: "1234",
-			},
-			expected: map[string]interface{}{
-				common.BacnetDeviceInstance: 1234,
-			},
-		},
-		{
-			protocol: common.BacnetIP,
-			properties: map[string]interface{}{
-				common.BacnetDeviceInstance: "4194302",
-			},
-			expected: map[string]interface{}{
-				common.BacnetDeviceInstance: 4194302,
-			},
-		},
-		{
-			protocol: common.BacnetIP,
-			properties: map[string]interface{}{
-				common.BacnetAddress: "192.168.60.123",
-				common.BacnetPort:    "47809",
-			},
-			expected: map[string]interface{}{
-				common.BacnetAddress: "192.168.60.123",
-				common.BacnetPort:    47809,
-			},
-		},
-		{
-			protocol: common.Opcua,
-			properties: map[string]interface{}{
-				common.OpcuaRequestedSessionTimeout:    "1200000",
-				common.OpcuaBrowseDepth:                "0",
-				common.OpcuaBrowsePublishInterval:      "5.2",
-				common.OpcuaConnectionReadingPostDelay: "0",
-				common.OpcuaIDType:                     "1",
-				common.OpcuaReadBatchSize:              "15",
-				common.OpcuaWriteBatchSize:             "10",
-				common.OpcuaNodesPerBrowse:             "5",
-				common.OpcuaSessionKeepAliveInterval:   "1000",
-			},
-			expected: map[string]interface{}{
-				common.OpcuaRequestedSessionTimeout:    1200000,
-				common.OpcuaBrowseDepth:                0,
-				common.OpcuaBrowsePublishInterval:      5.2,
-				common.OpcuaConnectionReadingPostDelay: 0,
-				common.OpcuaIDType:                     "1",
-				common.OpcuaReadBatchSize:              15,
-				common.OpcuaWriteBatchSize:             10,
-				common.OpcuaNodesPerBrowse:             5,
-				common.OpcuaSessionKeepAliveInterval:   1000.0,
-			},
-		},
-		{
-			protocol: common.ModbusTcp,
-			properties: map[string]interface{}{
-				common.ModbusUnitID:                    "1",
-				common.ModbusPort:                      "1234",
-				common.ModbusReadMaxHoldingRegisters:   "125",
-				common.ModbusReadMaxInputRegisters:     "125",
-				common.ModbusReadMaxBitsCoils:          "2000",
-				common.ModbusReadMaxBitsDiscreteInputs: "2000",
-				common.ModbusWriteMaxHoldingRegisters:  "123",
-				common.ModbusWriteMaxBitsCoils:         "1968",
-			},
-			expected: map[string]interface{}{
-				common.ModbusUnitID:                    1,
-				common.ModbusPort:                      1234,
-				common.ModbusReadMaxHoldingRegisters:   125,
-				common.ModbusReadMaxInputRegisters:     125,
-				common.ModbusReadMaxBitsCoils:          2000,
-				common.ModbusReadMaxBitsDiscreteInputs: 2000,
-				common.ModbusWriteMaxHoldingRegisters:  123,
-				common.ModbusWriteMaxBitsCoils:         1968,
-			},
-		},
-		{
-			protocol: common.ModbusRtu,
-			properties: map[string]interface{}{
-				common.ModbusUnitID:                    "1",
-				common.ModbusBaudRate:                  "0",
-				common.ModbusDataBits:                  "5",
-				common.ModbusStopBits:                  "1",
-				common.ModbusReadMaxHoldingRegisters:   "125",
-				common.ModbusReadMaxInputRegisters:     "125",
-				common.ModbusReadMaxBitsCoils:          "2000",
-				common.ModbusReadMaxBitsDiscreteInputs: "2000",
-				common.ModbusWriteMaxHoldingRegisters:  "123",
-				common.ModbusWriteMaxBitsCoils:         "1968",
-			},
-			expected: map[string]interface{}{
-				common.ModbusUnitID:                    1,
-				common.ModbusBaudRate:                  0,
-				common.ModbusDataBits:                  5,
-				common.ModbusStopBits:                  1,
-				common.ModbusReadMaxHoldingRegisters:   125,
-				common.ModbusReadMaxInputRegisters:     125,
-				common.ModbusReadMaxBitsCoils:          2000,
-				common.ModbusReadMaxBitsDiscreteInputs: 2000,
-				common.ModbusWriteMaxHoldingRegisters:  123,
-				common.ModbusWriteMaxBitsCoils:         1968,
-			},
-		},
-		{
-			protocol: common.EtherNetIPExplicitConnected,
-			properties: map[string]interface{}{
-				common.EtherNetIPDeviceResource: "VendorID",
-				common.EtherNetIPRPI:            "3000",
-				common.EtherNetIPSaveValue:      "true",
-			},
-			expected: map[string]interface{}{
-				common.EtherNetIPDeviceResource: "VendorID",
-				common.EtherNetIPRPI:            3000,
-				common.EtherNetIPSaveValue:      true,
-			},
-		},
-		{
-			protocol: common.EtherNetIPO2T,
-			properties: map[string]interface{}{
-				common.EtherNetIPConnectionType: "p2p",
-				common.EtherNetIPRPI:            "10",
-				common.EtherNetIPPriority:       "low",
-				common.EtherNetIPOwnership:      "exclusive",
-			},
-			expected: map[string]interface{}{
-				common.EtherNetIPConnectionType: "p2p",
-				common.EtherNetIPRPI:            10,
-				common.EtherNetIPPriority:       "low",
-				common.EtherNetIPOwnership:      "exclusive",
-			},
-		},
-		{
-			protocol: common.EtherNetIPT2O,
-			properties: map[string]interface{}{
-				common.EtherNetIPConnectionType: "p2p",
-				common.EtherNetIPRPI:            "10",
-				common.EtherNetIPPriority:       "low",
-				common.EtherNetIPOwnership:      "exclusive",
-			},
-			expected: map[string]interface{}{
-				common.EtherNetIPConnectionType: "p2p",
-				common.EtherNetIPRPI:            10,
-				common.EtherNetIPPriority:       "low",
-				common.EtherNetIPOwnership:      "exclusive",
-			},
-		},
-		{
-			protocol: common.EtherNetIPKey,
-			properties: map[string]interface{}{
-				common.EtherNetIPMethod:        "exact",
-				common.EtherNetIPVendorID:      "10",
-				common.EtherNetIPDeviceType:    "72",
-				common.EtherNetIPProductCode:   "50",
-				common.EtherNetIPMajorRevision: "12",
-				common.EtherNetIPMinorRevision: "2",
-			},
-			expected: map[string]interface{}{
-				common.EtherNetIPMethod:        "exact",
-				common.EtherNetIPVendorID:      10,
-				common.EtherNetIPDeviceType:    72,
-				common.EtherNetIPProductCode:   50,
-				common.EtherNetIPMajorRevision: 12,
-				common.EtherNetIPMinorRevision: 2,
-			},
-		},
-	}
-	for _, testCase := range tests {
-		t.Run(testCase.protocol, func(t *testing.T) {
-			err := toXrtProperties(testCase.protocol, testCase.properties)
-			require.NoError(t, err)
-			assert.EqualValues(t, testCase.expected, testCase.properties)
-		})
-	}
-}
-
-func TestToXrType_Invalid(t *testing.T) {
-	tests := []struct {
-		protocol   string
-		properties map[string]interface{}
-	}{
-		{
-			protocol: common.ModbusTcp,
-			properties: map[string]interface{}{
-				common.ModbusPort: "test",
-			},
-		},
-		{
-			protocol: common.Opcua,
-			properties: map[string]interface{}{
-				common.OpcuaBrowsePublishInterval: "test",
-			},
-		},
-	}
-	for _, testCase := range tests {
-		t.Run(testCase.protocol, func(t *testing.T) {
-			err := toXrtProperties(testCase.protocol, testCase.properties)
-			require.Error(t, err)
-		})
-	}
 }
 
 func TestToEdgeXProperties(t *testing.T) {


### PR DESCRIPTION
Since the protocol properties support the interface in v3, we can remove the data type conversion of xrt protocol properties.