### PR TITLE
EDX-4855 Remove the header cell spaces of xlsx import

### DIFF
--- a/central/xlsx/reader.go
+++ b/central/xlsx/reader.go
@@ -56,9 +56,9 @@ func getStructFieldByHeader(structEle *reflect.Value, colIndex int, headerCol []
 	headerLastIndex := len(headerCol) - 1
 	// check if row length is larger than the header
 	if colIndex > headerLastIndex {
-		headerName = headerCol[headerLastIndex]
+		headerName = strings.TrimSpace(headerCol[headerLastIndex])
 	} else {
-		headerName = headerCol[colIndex]
+		headerName = strings.TrimSpace(headerCol[colIndex])
 	}
 	field := structEle.FieldByName(headerName)
 	return headerName, field

--- a/central/xlsx/reader_test.go
+++ b/central/xlsx/reader_test.go
@@ -53,10 +53,16 @@ func Test_readStruct(t *testing.T) {
 
 func Test_getStructFieldByHeader(t *testing.T) {
 	rowElement := reflect.New(reflect.TypeOf(dtos.DeviceProfile{})).Elem()
-	headerCol := []string{"Name"}
+	colNameWithoutSpace := "Manufacturer"
+	colNameWithSpace := " " + colNameWithoutSpace
+	headerCol := []string{"Name", colNameWithSpace}
 	headerName, field := getStructFieldByHeader(&rowElement, 0, headerCol)
 	require.Equal(t, "Name", headerName)
 	require.Equal(t, reflect.String, field.Kind())
+
+	headerName2, field2 := getStructFieldByHeader(&rowElement, 1, headerCol)
+	require.Equal(t, colNameWithoutSpace, headerName2)
+	require.Equal(t, reflect.String, field2.Kind())
 }
 
 func Test_setStdStructFieldValue(t *testing.T) {


### PR DESCRIPTION
Remove the header cell leading/trailing spaces of xlsx import.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->