### PR TITLE
EDX-4908 Support multi-level prtProp device xlsx conversion

### DIFF
--- a/central/xlsx/constants.go
+++ b/central/xlsx/constants.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023 IOTech Ltd
+// Copyright (C) 2023-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,24 +39,7 @@ const (
 
 // constants relates to the Device protocol property keys
 const (
-	bacnetIPKey   = "BACnet-IP"
-	bacnetMSTPKey = "BACnet-MSTP"
-	bleKey        = "BLE"
-	ethernetIPKey = "ethernet-ip"
-	modbusRTUKey  = "modbus-rtu"
-	modbusTCPKey  = "modbus-tcp"
-	mqttKey       = "MQTT"
-	onvifKey      = "onvif"
-	opcuaKey      = "OPC-UA"
-	s7Key         = "S7"
-	usbKey        = "usb"
-	wsKey         = "ws"
-)
-
-// constants relates to the Device Protocol Name
-const (
-	usbCamera = "usb-camera"
-	websocket = "websocket"
+	modbusRTUKey = "modbus-rtu"
 )
 
 const mappingPathSeparator = "."

--- a/central/xlsx/device_test.go
+++ b/central/xlsx/device_test.go
@@ -34,7 +34,9 @@ var (
 	validDeviceRow = []any{
 		mockDeviceName1, "test-rtu-device 30001", "device-modbus", modbusRTUKey, "modbus-rtu-labels1,modbus-rtu-labels2", "LOCKED", mockDeviceAddress, mockDeviceBaudRate, mockDeviceDataBits, mockDeviceParity, mockDeviceStopBits, mockDeviceUnitID, "rtu-profile", mockTags1,
 	}
-	emptyValidateErr = map[string]error{}
+	emptyValidateErr     = map[string]error{}
+	mockExtraPropObj     = "extraPropObj"
+	mockExtraPrtPropName = "foo"
 )
 
 func Test_newDeviceXlsx(t *testing.T) {
@@ -163,6 +165,14 @@ func createMappingTableSheet(f *excelize.File) error {
 	err = sw.SetRow("A12",
 		[]any{
 			"MachineType", "tags.MachineType", "",
+		})
+	if err != nil {
+		return err
+	}
+
+	err = sw.SetRow("A13",
+		[]any{
+			mockExtraPrtPropName, "protocols." + mockExtraPropObj + "." + mockExtraPrtPropName, "",
 		})
 	if err != nil {
 		return err

--- a/central/xlsx/reader.go
+++ b/central/xlsx/reader.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023 IOTech Ltd
+// Copyright (C) 2023-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -121,57 +121,13 @@ func convertDTOStdTypeFields(rowElement *reflect.Value, xlsxRow []string, header
 	return nil
 }
 
-// setProtocolPropMap sets the ProtocolProperties outer map key based on protocol and returns the Protocols map
-func setProtocolPropMap(prtProps map[string]any, fieldMappings map[string]mappingField) (map[string]dtos.ProtocolProperties, errors.EdgeX) {
-	var protocol string
-	prtPropMap := make(map[string]dtos.ProtocolProperties)
-
-	if mapping, ok := fieldMappings[protocolName]; ok {
-		if mapping.defaultValue == "" {
-			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "the default value of ProtocolName not defined in MappingTable sheet", nil)
-		}
-		protocol = mapping.defaultValue
-	} else {
-		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "ProtocolName not defined in MappingTable sheet", nil)
-	}
-
-	switch strings.ToLower(protocol) {
-	case strings.ToLower(bacnetIPKey):
-		prtPropMap[bacnetIPKey] = prtProps
-	case strings.ToLower(bacnetMSTPKey):
-		prtPropMap[bacnetMSTPKey] = prtProps
-	case strings.ToLower(bleKey):
-		prtPropMap[bleKey] = prtProps
-	case strings.ToLower(ethernetIPKey):
-		prtPropMap[ethernetIPKey] = prtProps
-	case strings.ToLower(modbusRTUKey):
-		prtPropMap[modbusRTUKey] = prtProps
-	case strings.ToLower(modbusTCPKey):
-		prtPropMap[modbusTCPKey] = prtProps
-	case strings.ToLower(mqttKey):
-		prtPropMap[mqttKey] = prtProps
-	case strings.ToLower(onvifKey):
-		prtPropMap[onvifKey] = prtProps
-	case strings.ToLower(opcuaKey):
-		prtPropMap[opcuaKey] = prtProps
-	case strings.ToLower(s7Key):
-		prtPropMap[s7Key] = prtProps
-	case strings.ToLower(usbCamera):
-		prtPropMap[usbKey] = prtProps
-	case strings.ToLower(websocket):
-		prtPropMap[wsKey] = prtProps
-	default:
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("unknown ProtocolProperties outer key for '%s' protocol", protocol), nil)
-	}
-	return prtPropMap, nil
-}
-
 // convertDeviceFields convert the xlsx row to the Device DTO
 func convertDeviceFields(rowElement *reflect.Value, xlsxRow []string, headerCol []string, fieldMappings map[string]mappingField) errors.EdgeX {
 	if fieldMappings == nil {
 		return errors.NewCommonEdgeX(errors.KindServerError, "fieldMappings not defined while converting device fields", nil)
 	}
-	protocolProperties := dtos.ProtocolProperties{}
+
+	prtPropMap := make(map[string]dtos.ProtocolProperties)
 	propertiesMap := make(map[string]any)
 	tagsMap := make(map[string]any)
 
@@ -209,8 +165,40 @@ func convertDeviceFields(rowElement *reflect.Value, xlsxRow []string, headerCol 
 
 					switch fieldPrefix {
 					case strings.ToLower(protocols):
-						// set the cell to Protocols map
-						protocolProperties[headerName] = convertedValue
+						// get the Device protocols field
+						prtMapField := rowElement.FieldByName(protocols)
+						if prtMapField.Len() > 0 {
+							// convert the prtMapField reflect.Value to map[string]ProtocolProperties
+							prtPropMap = prtMapField.Interface().(map[string]dtos.ProtocolProperties)
+						}
+
+						// to handle the nested ProtocolProperties name
+						// split the ProtocolProperties name using the "." separator into array
+						prtPropNames := strings.Split(fieldName, mappingPathSeparator)
+						lastPropNameIdx := len(prtPropNames) - 1
+
+						var innerPrtProp dtos.ProtocolProperties
+						for i, propName := range prtPropNames {
+							if i == lastPropNameIdx {
+								// the last part of ProtocolProperties property name
+								innerPrtProp[propName] = convertedValue
+							} else {
+								if i == 0 {
+									if _, ok := prtPropMap[propName]; !ok {
+										prtPropMap[propName] = make(dtos.ProtocolProperties)
+									}
+									// assign prtPropMap[propName] to innerPrtProp
+									innerPrtProp = prtPropMap[propName]
+								} else {
+									if _, ok := innerPrtProp[propName]; !ok {
+										// initialize a new ProtocolProperties map for inner node
+										innerPrtProp[propName] = make(dtos.ProtocolProperties)
+									}
+									innerPrtProp = innerPrtProp[propName].(dtos.ProtocolProperties)
+								}
+							}
+						}
+						prtMapField.Set(reflect.ValueOf(prtPropMap))
 					case strings.ToLower(properties):
 						// set the cell to Protocols map
 						propertiesMap[fieldName] = convertedValue
@@ -226,18 +214,6 @@ func convertDeviceFields(rowElement *reflect.Value, xlsxRow []string, headerCol 
 		}
 	}
 
-	// set Protocols field to the Device DTO struct
-	if len(protocolProperties) > 0 {
-		prtField := rowElement.FieldByName(protocols)
-		if prtField.Kind() == reflect.Invalid {
-			return errors.NewCommonEdgeX(errors.KindServerError, "failed to find Protocols field in Device DTO", nil)
-		}
-		prtPropMap, err := setProtocolPropMap(protocolProperties, fieldMappings)
-		if err != nil {
-			return err
-		}
-		prtField.Set(reflect.ValueOf(prtPropMap))
-	}
 	// set Properties field to the Device DTO struct
 	if len(propertiesMap) > 0 {
 		err := setMapToStructField(rowElement, properties, propertiesMap)

--- a/central/xlsx/reader.go
+++ b/central/xlsx/reader.go
@@ -169,7 +169,10 @@ func convertDeviceFields(rowElement *reflect.Value, xlsxRow []string, headerCol 
 						prtMapField := rowElement.FieldByName(protocols)
 						if prtMapField.Len() > 0 {
 							// convert the prtMapField reflect.Value to map[string]ProtocolProperties
-							prtPropMap = prtMapField.Interface().(map[string]dtos.ProtocolProperties)
+							prtPropMap, ok = prtMapField.Interface().(map[string]dtos.ProtocolProperties)
+							if !ok {
+								return errors.NewCommonEdgeX(errors.KindServerError, "failed to convert Device Protocols field to map[string]ProtocolProperties data type", nil)
+							}
 						}
 
 						// to handle the nested ProtocolProperties name
@@ -194,7 +197,11 @@ func convertDeviceFields(rowElement *reflect.Value, xlsxRow []string, headerCol 
 										// initialize a new ProtocolProperties map for inner node
 										innerPrtProp[propName] = make(dtos.ProtocolProperties)
 									}
-									innerPrtProp = innerPrtProp[propName].(dtos.ProtocolProperties)
+									innerPrtProp, ok = innerPrtProp[propName].(dtos.ProtocolProperties)
+									if !ok {
+										return errors.NewCommonEdgeX(errors.KindServerError,
+											fmt.Sprintf("failed to convert property '%s' from '%s' path to ProtocolProperties type", propName, mapping.path), nil)
+									}
 								}
 							}
 						}


### PR DESCRIPTION
Support multi-level/nested protocolProperties device xlsx conversion.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->