### PR TITLE
EDX-4993 Add more resource property fields to be converted

### DIFF
--- a/central/xlsx/constants.go
+++ b/central/xlsx/constants.go
@@ -39,13 +39,22 @@ const (
 	description        = "Description"
 	isHidden           = "IsHidden"
 	readWrite          = "ReadWrite"
+	units              = "Units"
+	minimum            = "Minimum"
+	maximum            = "Maximum"
+	defaultValue       = "DefaultValue"
+	mask               = "Mask"
+	shift              = "Shift"
+	scale              = "Scale"
+	base               = "Base"
+	assertion          = "Assertion"
+	mediaType          = "MediaType"
 	resourceOperation  = "ResourceOperation"
 )
 
 // constants relates to the Device protocols
 const (
 	modbusRTU = "modbus-rtu"
-	modbusTCP = "modbus-tcp"
 )
 
 const mappingPathSeparator = "."

--- a/central/xlsx/dpXlsxWriter.go
+++ b/central/xlsx/dpXlsxWriter.go
@@ -150,6 +150,42 @@ func (dpWriter *dpXlsxWriter) convertDeviceResources() errors.EdgeX {
 						cell = res.Properties.ValueType
 					case strings.ToLower(readWrite):
 						cell = res.Properties.ReadWrite
+					case strings.ToLower(units):
+						cell = res.Properties.Units
+					case strings.ToLower(minimum):
+						if res.Properties.Minimum != nil {
+							cell = *res.Properties.Minimum
+						}
+					case strings.ToLower(maximum):
+						if res.Properties.Maximum != nil {
+							cell = *res.Properties.Maximum
+						}
+					case strings.ToLower(defaultValue):
+						cell = res.Properties.DefaultValue
+					case strings.ToLower(mask):
+						if res.Properties.Mask != nil {
+							cell = *res.Properties.Mask
+						}
+					case strings.ToLower(shift):
+						if res.Properties.Shift != nil {
+							cell = *res.Properties.Shift
+						}
+					case strings.ToLower(scale):
+						if res.Properties.Scale != nil {
+							cell = *res.Properties.Scale
+						}
+					case strings.ToLower(common.Offset):
+						if res.Properties.Offset != nil {
+							cell = *res.Properties.Offset
+						}
+					case strings.ToLower(base):
+						if res.Properties.Base != nil {
+							cell = *res.Properties.Base
+						}
+					case strings.ToLower(assertion):
+						cell = res.Properties.Assertion
+					case strings.ToLower(mediaType):
+						cell = res.Properties.MediaType
 					default:
 						continue
 					}

--- a/central/xlsx/dpXlsxWriter_test.go
+++ b/central/xlsx/dpXlsxWriter_test.go
@@ -7,6 +7,7 @@ package xlsx
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -73,6 +74,7 @@ func Test_dpWriter_convertDeviceResources(t *testing.T) {
 	defer f.Close()
 
 	mockAttrValue := "HOLDING_REGISTERS"
+	minValue := float64(0)
 	mockResource := dtos.DeviceResource{
 		Description: "this is the mockRes1 resource",
 		Name:        "mockRes1",
@@ -80,6 +82,7 @@ func Test_dpWriter_convertDeviceResources(t *testing.T) {
 		Properties: dtos.ResourceProperties{
 			ValueType: "Float32",
 			ReadWrite: common.ReadWrite_R,
+			Minimum:   &minValue,
 		},
 		Attributes: map[string]any{"primaryTable": mockAttrValue},
 	}
@@ -93,6 +96,30 @@ func Test_dpWriter_convertDeviceResources(t *testing.T) {
 	value, err := xlsxWriter.xlsxFile.GetCellValue(deviceResourceSheetName, "A2")
 	require.NoError(t, err)
 	require.Equal(t, mockResource.Name, value)
+
+	value, err = xlsxWriter.xlsxFile.GetCellValue(deviceResourceSheetName, "B2")
+	require.NoError(t, err)
+	require.Equal(t, strconv.FormatBool(mockResource.IsHidden), value)
+
+	value, err = xlsxWriter.xlsxFile.GetCellValue(deviceResourceSheetName, "C2")
+	require.NoError(t, err)
+	require.Equal(t, mockResource.Description, value)
+
+	value, err = xlsxWriter.xlsxFile.GetCellValue(deviceResourceSheetName, "D2")
+	require.NoError(t, err)
+	require.Equal(t, mockResource.Properties.ValueType, value)
+
+	value, err = xlsxWriter.xlsxFile.GetCellValue(deviceResourceSheetName, "E2")
+	require.NoError(t, err)
+	require.Equal(t, mockResource.Properties.ReadWrite, value)
+
+	value, err = xlsxWriter.xlsxFile.GetCellValue(deviceResourceSheetName, "F2")
+	require.NoError(t, err)
+	require.Equal(t, mockAttrValue, value)
+
+	value, err = xlsxWriter.xlsxFile.GetCellValue(deviceResourceSheetName, "G2")
+	require.NoError(t, err)
+	require.Equal(t, strconv.FormatFloat(*mockResource.Properties.Minimum, 'g', -1, 64), value)
 }
 
 func Test_dpWriter_convertDeviceCommand(t *testing.T) {

--- a/central/xlsx/transform_test.go
+++ b/central/xlsx/transform_test.go
@@ -165,11 +165,12 @@ func createXlsxTemplateFile() (*excelize.File, error) {
 		return nil, err
 	}
 
+	resourceHeader := append(validResourceHeader, "Minimum")
 	sw, err = f.NewStreamWriter(deviceResourceSheetName)
 	if err != nil {
 		return nil, err
 	}
-	err = sw.SetRow("A1", validResourceHeader)
+	err = sw.SetRow("A1", resourceHeader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add more resource property fields to be converted from DTO to xlsx file.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->