### PR TITLE
GUIT-1079 Add transform v2 DeviceProfile DTO to v3 func

### DIFF
--- a/central/dtos/transform.go
+++ b/central/dtos/transform.go
@@ -1,0 +1,149 @@
+//
+// Copyright (C) 2024 IOTech Ltd
+//
+
+package dtos
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/v2dtos"
+)
+
+// TransformProfileFromV2ToV3 converts the v2 DeviceProfile DTO to v3
+func TransformProfileFromV2ToV3(v2Profile v2dtos.DeviceProfile) (dtos.DeviceProfile, errors.EdgeX) {
+	resources, err := transformResourceFromV2ToV3(v2Profile.DeviceResources)
+	if err != nil {
+		return dtos.DeviceProfile{}, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	profile := dtos.DeviceProfile{
+		DBTimestamp:            dtos.DBTimestamp(v2Profile.DBTimestamp),
+		DeviceProfileBasicInfo: dtos.DeviceProfileBasicInfo(v2Profile.DeviceProfileBasicInfo),
+		DeviceResources:        resources,
+		DeviceCommands:         transformCommandFromV2ToV3(v2Profile.DeviceCommands),
+		ApiVersion:             common.ApiVersion,
+	}
+	return profile, nil
+}
+
+// transformResourceFromV2ToV3 converts the v2 []DeviceResource DTO to v3
+func transformResourceFromV2ToV3(v2Resources []v2dtos.DeviceResource) ([]dtos.DeviceResource, errors.EdgeX) {
+	var deviceResources []dtos.DeviceResource
+	for _, v2Res := range v2Resources {
+		resProps, err := transformResPropsFromV2ToV3(v2Res.Properties)
+		if err != nil {
+			return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to convert v2 ResourceProperties DTO to v3", err)
+		}
+
+		dr := dtos.DeviceResource{
+			Description: v2Res.Description,
+			Name:        v2Res.Name,
+			IsHidden:    v2Res.IsHidden,
+			Properties:  resProps,
+			Attributes:  v2Res.Attributes,
+			Tags:        v2Res.Tags,
+			Tag:         v2Res.Tag,
+		}
+		deviceResources = append(deviceResources, dr)
+	}
+	return deviceResources, nil
+}
+
+// transformResPropsFromV2ToV3 converts the v2 ResourceProperties DTO to v3
+func transformResPropsFromV2ToV3(v2ResProp v2dtos.ResourceProperties) (dtos.ResourceProperties, errors.EdgeX) {
+	var err error
+	var minimum, maximum, scale, offset, base float64
+	var mask uint64
+	var shift int64
+
+	if v2ResProp.Minimum != "" {
+		minimum, err = strconv.ParseFloat(v2ResProp.Minimum, 64)
+		if err != nil {
+			return dtos.ResourceProperties{}, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse minimum value '%s' to float64", v2ResProp.Minimum), err)
+		}
+	}
+	if v2ResProp.Maximum != "" {
+		maximum, err = strconv.ParseFloat(v2ResProp.Maximum, 64)
+		if err != nil {
+			return dtos.ResourceProperties{}, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse maximum value '%s' to float64", v2ResProp.Maximum), err)
+		}
+	}
+	if v2ResProp.Mask != "" {
+		mask, err = strconv.ParseUint(v2ResProp.Mask, 10, 64)
+		if err != nil {
+			return dtos.ResourceProperties{}, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse mask value '%s' to uint64", v2ResProp.Mask), err)
+		}
+	}
+	if v2ResProp.Shift != "" {
+		shift, err = strconv.ParseInt(v2ResProp.Shift, 10, 64)
+		if err != nil {
+			return dtos.ResourceProperties{}, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse shift value '%s' to int64", v2ResProp.Shift), err)
+		}
+	}
+	if v2ResProp.Scale != "" {
+		scale, err = strconv.ParseFloat(v2ResProp.Scale, 64)
+		if err != nil {
+			return dtos.ResourceProperties{}, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse scale value '%s' to float64", v2ResProp.Scale), err)
+		}
+	}
+	if v2ResProp.Offset != "" {
+		offset, err = strconv.ParseFloat(v2ResProp.Offset, 64)
+		if err != nil {
+			return dtos.ResourceProperties{}, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse offset value '%s' to float64", v2ResProp.Offset), err)
+		}
+	}
+	if v2ResProp.Base != "" {
+		base, err = strconv.ParseFloat(v2ResProp.Base, 64)
+		if err != nil {
+			return dtos.ResourceProperties{}, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse base value '%s' to float64", v2ResProp.Base), err)
+		}
+	}
+
+	return dtos.ResourceProperties{
+		ValueType:    v2ResProp.ValueType,
+		ReadWrite:    v2ResProp.ReadWrite,
+		Units:        v2ResProp.Units,
+		Minimum:      &minimum,
+		Maximum:      &maximum,
+		DefaultValue: v2ResProp.DefaultValue,
+		Mask:         &mask,
+		Shift:        &shift,
+		Scale:        &scale,
+		Offset:       &offset,
+		Base:         &base,
+		Assertion:    v2ResProp.Assertion,
+		MediaType:    v2ResProp.MediaType,
+		Optional:     nil,
+	}, nil
+}
+
+// transformCommandFromV2ToV3 converts the v2 []DeviceCommand DTO to v3
+func transformCommandFromV2ToV3(v2Commands []v2dtos.DeviceCommand) []dtos.DeviceCommand {
+	var deviceCommands []dtos.DeviceCommand
+	for _, v2Command := range v2Commands {
+		dc := dtos.DeviceCommand{
+			Name:               v2Command.Name,
+			IsHidden:           v2Command.IsHidden,
+			ReadWrite:          v2Command.ReadWrite,
+			ResourceOperations: transformResourceOperationFromV2ToV3(v2Command.ResourceOperations),
+			Tags:               v2Command.Tags,
+		}
+		deviceCommands = append(deviceCommands, dc)
+	}
+	return deviceCommands
+}
+
+// transformResourceOperationFromV2ToV3 converts the v2 []ResourceOperation DTO to v3
+func transformResourceOperationFromV2ToV3(v2ResOps []v2dtos.ResourceOperation) []dtos.ResourceOperation {
+	var ros []dtos.ResourceOperation
+	for _, v2ro := range v2ResOps {
+		ro := dtos.ResourceOperation(v2ro)
+		ros = append(ros, ro)
+	}
+	return ros
+}

--- a/central/dtos/transform_test.go
+++ b/central/dtos/transform_test.go
@@ -1,0 +1,110 @@
+//
+// Copyright (C) 2024 IOTech Ltd
+//
+
+package dtos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/v2dtos"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockDeviceResourceName   = "mockRes1"
+	v2MockResourceOperations = []v2dtos.ResourceOperation{{DeviceResource: mockDeviceResourceName}}
+	v3MockResourceOperation  = []dtos.ResourceOperation{dtos.ResourceOperation(v2MockResourceOperations[0])}
+	mockReadWrite            = "R"
+	mockValueType            = "Float64"
+	mockMin                  = 100.00
+	mockMax                  = 10000.00
+	mockV2ResProp            = v2dtos.ResourceProperties{
+		ValueType: mockValueType,
+		ReadWrite: mockReadWrite,
+		Minimum:   fmt.Sprintf("%f", mockMin),
+		Maximum:   fmt.Sprintf("%f", mockMax),
+	}
+	mockResProp = dtos.ResourceProperties{
+		ValueType: mockValueType,
+		ReadWrite: mockReadWrite,
+		Minimum:   &mockMin,
+		Maximum:   &mockMax,
+	}
+	mockAttributes  = map[string]any{"foo": "bar"}
+	mockV2DeviceRes = v2dtos.DeviceResource{
+		Name:       mockDeviceResourceName,
+		IsHidden:   false,
+		Properties: mockV2ResProp,
+		Attributes: mockAttributes,
+	}
+	mockDeviceRes = dtos.DeviceResource{
+		Name:       mockDeviceResourceName,
+		IsHidden:   false,
+		Properties: mockResProp,
+		Attributes: mockAttributes,
+	}
+	mockDeviceCommandName = "mockDC1"
+	mockV2DeviceCommand   = v2dtos.DeviceCommand{
+		Name:               mockDeviceCommandName,
+		IsHidden:           false,
+		ReadWrite:          mockReadWrite,
+		ResourceOperations: v2MockResourceOperations,
+	}
+	mockDeviceCommand = dtos.DeviceCommand{
+		Name:               mockDeviceCommandName,
+		IsHidden:           false,
+		ReadWrite:          mockReadWrite,
+		ResourceOperations: v3MockResourceOperation,
+	}
+)
+
+func Test_TransformProfileFromV2ToV3(t *testing.T) {
+	mockDeviceProfileName := "mockPro1"
+	mockManufacturerName := "DNZ"
+	mockV2Profile := v2dtos.DeviceProfile{
+		ApiVersion: "v2",
+		DeviceProfileBasicInfo: v2dtos.DeviceProfileBasicInfo{
+			Name:         mockDeviceProfileName,
+			Manufacturer: mockManufacturerName,
+		},
+		DeviceResources: []v2dtos.DeviceResource{mockV2DeviceRes},
+		DeviceCommands:  []v2dtos.DeviceCommand{mockV2DeviceCommand},
+	}
+	result, err := TransformProfileFromV2ToV3(mockV2Profile)
+	require.NoError(t, err)
+	require.Equal(t, mockDeviceProfileName, result.Name)
+	require.Equal(t, mockManufacturerName, result.Manufacturer)
+	require.Equal(t, mockV2DeviceRes.Name, result.DeviceResources[0].Name)
+	require.Equal(t, mockV2DeviceCommand.Name, result.DeviceCommands[0].Name)
+}
+
+func Test_transformResourceFromV2ToV3(t *testing.T) {
+	result, err := transformResourceFromV2ToV3([]v2dtos.DeviceResource{mockV2DeviceRes})
+	require.NoError(t, err)
+	require.Equal(t, mockDeviceRes.Name, result[0].Name)
+	require.Equal(t, mockDeviceRes.Attributes, result[0].Attributes)
+}
+
+func Test_transformResPropsFromV2ToV3(t *testing.T) {
+	result, err := transformResPropsFromV2ToV3(mockV2ResProp)
+	require.NoError(t, err)
+	require.Equal(t, mockResProp.ValueType, result.ValueType)
+	require.Equal(t, mockResProp.ReadWrite, result.ReadWrite)
+	require.Equal(t, *mockResProp.Minimum, *result.Minimum)
+	require.Equal(t, *mockResProp.Maximum, *result.Maximum)
+}
+
+func Test_transformCommandFromV2ToV3(t *testing.T) {
+	expected := []dtos.DeviceCommand{mockDeviceCommand}
+	results := transformCommandFromV2ToV3([]v2dtos.DeviceCommand{mockV2DeviceCommand})
+	require.Equal(t, expected, results)
+}
+
+func Test_transformResourceOperationFromV2ToV3(t *testing.T) {
+	result := transformResourceOperationFromV2ToV3(v2MockResourceOperations)
+	require.Equal(t, v3MockResourceOperation, result)
+}


### PR DESCRIPTION
Add the transform v2 DeviceProfile DTO to v3 function.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->