### PR TITLE
EDX-5171 Fix the error when no response in DeleteRequest http func

### DIFF
--- a/clients/http/utils/request.go
+++ b/clients/http/utils/request.go
@@ -233,6 +233,12 @@ func DeleteRequest(ctx context.Context, returnValuePointer interface{}, baseUrl 
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
+	}
+
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
 	}

--- a/clients/http/utils/request.go
+++ b/clients/http/utils/request.go
@@ -80,6 +80,10 @@ func GetRequestWithBodyRawData(ctx context.Context, returnValuePointer interface
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
+	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
 	}
@@ -102,6 +106,10 @@ func PostRequest(
 	res, err := sendRequest(ctx, req, authInjector)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
 	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
@@ -126,6 +134,10 @@ func PostRequestWithRawData(
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
+	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
 	}
@@ -148,6 +160,10 @@ func PutRequest(
 	res, err := sendRequest(ctx, req, authInjector)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
 	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
@@ -172,6 +188,10 @@ func PatchRequest(
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
+	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
 	}
@@ -193,6 +213,10 @@ func PostByFileRequest(
 	res, err := sendRequest(ctx, req, authInjector)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
 	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
@@ -216,6 +240,10 @@ func PutByFileRequest(
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
+	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
 	}
@@ -233,12 +261,10 @@ func DeleteRequest(ctx context.Context, returnValuePointer interface{}, baseUrl 
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
-
 	if len(res) == 0 {
 		// no response body is returned from the http request
 		return nil
 	}
-
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
 	}
@@ -255,6 +281,10 @@ func DeleteRequestWithParams(ctx context.Context, returnValuePointer interface{}
 	res, err := sendRequest(ctx, req, authInjector)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(res) == 0 {
+		// no response body is returned from the http request
+		return nil
 	}
 	if err := json.Unmarshal(res, returnValuePointer); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)


### PR DESCRIPTION
Not unmarshal to returnValuePointer if no response returned from http request.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->