### PR TITLE
feat: Add onChangeThreshold in Device AutoEvent

### DIFF
--- a/dtos/autoevent.go
+++ b/dtos/autoevent.go
@@ -10,17 +10,19 @@ import (
 )
 
 type AutoEvent struct {
-	Interval   string `json:"interval" yaml:"interval" validate:"required,edgex-dto-duration=1ms"` // min/max can be defined as params, ex. edgex-dto-duration=10ms0x2C24h
-	OnChange   bool   `json:"onChange" yaml:"onChange"`
-	SourceName string `json:"sourceName" yaml:"sourceName" validate:"required"`
+	Interval          string  `json:"interval" yaml:"interval" validate:"required,edgex-dto-duration=1ms"` // min/max can be defined as params, ex. edgex-dto-duration=10ms0x2C24h
+	OnChange          bool    `json:"onChange" yaml:"onChange"`
+	OnChangeThreshold float64 `json:"onChangeThreshold" yaml:"onChangeThreshold" validate:"gte=0"`
+	SourceName        string  `json:"sourceName" yaml:"sourceName" validate:"required"`
 }
 
 // ToAutoEventModel transforms the AutoEvent DTO to the AutoEvent model
 func ToAutoEventModel(a AutoEvent) models.AutoEvent {
 	return models.AutoEvent{
-		Interval:   a.Interval,
-		OnChange:   a.OnChange,
-		SourceName: a.SourceName,
+		Interval:          a.Interval,
+		OnChange:          a.OnChange,
+		OnChangeThreshold: a.OnChangeThreshold,
+		SourceName:        a.SourceName,
 	}
 }
 
@@ -36,9 +38,10 @@ func ToAutoEventModels(autoEventDTOs []AutoEvent) []models.AutoEvent {
 // FromAutoEventModelToDTO transforms the AutoEvent model to the AutoEvent DTO
 func FromAutoEventModelToDTO(a models.AutoEvent) AutoEvent {
 	return AutoEvent{
-		Interval:   a.Interval,
-		OnChange:   a.OnChange,
-		SourceName: a.SourceName,
+		Interval:          a.Interval,
+		OnChange:          a.OnChange,
+		OnChangeThreshold: a.OnChangeThreshold,
+		SourceName:        a.SourceName,
 	}
 }
 

--- a/dtos/requests/device_test.go
+++ b/dtos/requests/device_test.go
@@ -22,7 +22,7 @@ import (
 var testDeviceLabels = []string{"MODBUS", "TEMP"}
 var testDeviceLocation = "{40lat;45long}"
 var testAutoEvents = []dtos.AutoEvent{
-	{SourceName: "TestDevice", Interval: "300ms", OnChange: true},
+	{SourceName: "TestDevice", Interval: "300ms", OnChange: true, OnChangeThreshold: 0.01},
 }
 var testAutoEventsWithInvalidFrequency = []dtos.AutoEvent{
 	{SourceName: "TestDevice", Interval: "300", OnChange: true},
@@ -124,6 +124,10 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 	noAutoEventResource.Device.AutoEvents = []dtos.AutoEvent{
 		{Interval: "300ms", OnChange: true},
 	}
+	invalidAutoEventOnChangeThreshold := testAddDevice
+	invalidAutoEventOnChangeThreshold.Device.AutoEvents = []dtos.AutoEvent{
+		{SourceName: "TestDevice", Interval: "300ms", OnChange: true, OnChangeThreshold: -0.01},
+	}
 	tests := []struct {
 		name        string
 		Device      AddDeviceRequest
@@ -139,11 +143,12 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 		{"valid AddDeviceRequest, no Protocols", noProtocols, false},
 		{"invalid AddDeviceRequest, no AutoEvent frequency", noAutoEventFrequency, true},
 		{"invalid AddDeviceRequest, no AutoEvent resource", noAutoEventResource, true},
+		{"invalid AddDeviceRequest, OnChangeThreshold should greater than or equal 0", invalidAutoEventOnChangeThreshold, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.Device.Validate()
-			assert.Equal(t, tt.expectError, err != nil, "Unexpected addDeviceRequest validation result.", err)
+			assert.Equal(t, tt.expectError, err != nil, "Unexpected addDeviceRequest validation result: %v", err)
 		})
 	}
 
@@ -245,7 +250,7 @@ func Test_AddDeviceReqToDeviceModels(t *testing.T) {
 			Location:       testDeviceLocation,
 			Tags:           map[string]any{"1": TestTag1, "2": TestTag2},
 			AutoEvents: []models.AutoEvent{
-				{SourceName: "TestDevice", Interval: "300ms", OnChange: true},
+				{SourceName: "TestDevice", Interval: "300ms", OnChange: true, OnChangeThreshold: 0.01},
 			},
 			Protocols: map[string]models.ProtocolProperties{
 				"modbus-ip": {

--- a/dtos/requests/provisionwatcher_test.go
+++ b/dtos/requests/provisionwatcher_test.go
@@ -194,7 +194,7 @@ func TestAddProvisionWatcherReqToProvisionWatcherModels(t *testing.T) {
 				ProfileName: TestDeviceProfileName,
 				AdminState:  models.Locked,
 				AutoEvents: []models.AutoEvent{
-					{SourceName: "TestDevice", Interval: "300ms", OnChange: true},
+					{SourceName: "TestDevice", Interval: "300ms", OnChange: true, OnChangeThreshold: 0.01},
 				},
 			},
 		},

--- a/models/autoevent.go
+++ b/models/autoevent.go
@@ -6,7 +6,8 @@
 package models
 
 type AutoEvent struct {
-	Interval   string
-	OnChange   bool
-	SourceName string
+	Interval          string
+	OnChange          bool
+	OnChangeThreshold float64
+	SourceName        string
 }

--- a/xrtmodels/schedule.go
+++ b/xrtmodels/schedule.go
@@ -3,12 +3,13 @@ package xrtmodels
 // Schedule is used to register timed, polled reads of device resources
 // The definition can refer to https://github.com/IOTechSystems/xrt-docs/blob/v2.0-branch/docs/mqtt-management/mqtt-management.md#schedule-format
 type Schedule struct {
-	Name     string      `json:"name"`
-	Device   string      `json:"device"`
-	Resource []string    `json:"resource"`
-	Interval uint64      `json:"interval,omitempty"`
-	OnChange bool        `json:"on_change"`
-	Publish  bool        `json:"publish"`
-	Units    bool        `json:"units"`
-	Options  interface{} `json:"options,omitempty"`
+	Name     string             `json:"name"`
+	Device   string             `json:"device"`
+	Resource []string           `json:"resource"`
+	Interval uint64             `json:"interval,omitempty"`
+	OnChange bool               `json:"on_change"`
+	Bounds   map[string]float64 `json:"bounds"`
+	Publish  bool               `json:"publish"`
+	Units    bool               `json:"units"`
+	Options  interface{}        `json:"options,omitempty"`
 }


### PR DESCRIPTION
The onChange flag in Device AutoEvent can prevent any non changed values sent out. The onChangeThreshold could provide the advanced feature, and the default value is 0, any changed value that exceeds (>) bounds shall be published. For example, Current_value - Current_prev > 0.01 shall be published where "Current_value" is the new value and "Current_prev" is the previously published value.