### PR TITLE
fix: Allow binary reading value to be empty

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -41,7 +41,7 @@ type SimpleReading struct {
 }
 
 type BinaryReading struct {
-	BinaryValue []byte `json:"binaryValue,omitempty" validate:"omitempty,gt=0"`
+	BinaryValue []byte `json:"binaryValue,omitempty" validate:"omitempty"`
 	MediaType   string `json:"mediaType,omitempty" validate:"required_with=BinaryValue"`
 }
 

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -120,7 +120,7 @@ func TestAddEventRequest_Validate(t *testing.T) {
 		{"invalid AddEventRequest, no Reading ValueType", invalidReadingNoValueType, true},
 		{"invalid AddEventRequest, invalid Reading ValueType", invalidReadingInvalidValueType, true},
 		{"invalid AddEventRequest, no SimpleReading Value", invalidSimpleReadingNoValue, true},
-		{"invalid AddEventRequest, no BinaryReading BinaryValue", invalidBinaryReadingNoValue, true},
+		{"valid AddEventRequest, no BinaryReading BinaryValue", invalidBinaryReadingNoValue, false},
 		{"invalid AddEventRequest, no BinaryReading MediaType", invalidBinaryReadingNoMedia, true},
 		{"valid AddEventRequest, nil Binary value", nilBinaryReadingNoMedia, false},
 		{"valid AddEventRequest, nil Simple value", nilSimpleReading, false},


### PR DESCRIPTION
Since we accept the nil reading value, the binary reading value can be empty.

Signed-off-by: bruce <weichou1229@gmail.com>
(cherry picked from commit d524d8c204f739d8b5b86ef1ba60ec8e5cd14733)
